### PR TITLE
Channel result component(s)

### DIFF
--- a/__tests__/componentTests/TwitchChannelResult.test.tsx
+++ b/__tests__/componentTests/TwitchChannelResult.test.tsx
@@ -34,7 +34,7 @@ describe('Twitch channel result component', () => {
   it('Includes channel thumbnail', () => {
     render(<TwitchChannelResult channelData={testData} />)
     const thumbnail = screen.getByRole('img');
-    expect(thumbnail).toBeInTheDocument()
+    expect(thumbnail).toBeInTheDocument();
   });
 
   it('Includes channel name', () => {
@@ -51,7 +51,7 @@ describe('Twitch channel result component', () => {
 
   it('Does not show LIVE indicator for currently offline channel', () => {
     render(<TwitchChannelResult channelData={testData} />)
-    const live = screen.getByText('LIVE');
+    const live = screen.queryByText('LIVE');
     expect(live).not.toBeInTheDocument()
   });
 

--- a/__tests__/componentTests/TwitchChannelResult.test.tsx
+++ b/__tests__/componentTests/TwitchChannelResult.test.tsx
@@ -10,13 +10,13 @@ const testData: HelixChannelSearchResult = {
   getGame: jest.fn,
   // @ts-expect-error exact getTags implementation not needed in these tests
   getTags: jest.fn,
-  displayName: "loserfruit",
+  displayName: "Loserfruit",
   gameId: "509658",
   gameName: "Just Chatting",
   id: "41245072",
   isLive: false,
   language: "en",
-  name: "smasherger",
+  name: "loserfruit",
   startDate: null,
   tagIds: [],
   thumbnailUrl: "https://static-cdn.jtvnw.net/jtv_user_pictures/fd17325a-7dc2-46c6-8617-e90ec259501c-profile_image-300x300.png"
@@ -30,13 +30,13 @@ const testDataLive: HelixChannelSearchResult = {
   getGame: jest.fn,
   // @ts-expect-error exact getTags implementation not needed in these tests
   getTags: jest.fn,
-  displayName: "loserfruit",
+  displayName: "Loserfruit",
   gameId: "509658",
   gameName: "Just Chatting",
   id: "41245072",
   isLive: true,
   language: "en",
-  name: "smasherger",
+  name: "loserfruit",
   startDate: null,
   tagIds: [],
   thumbnailUrl: "https://static-cdn.jtvnw.net/jtv_user_pictures/fd17325a-7dc2-46c6-8617-e90ec259501c-profile_image-300x300.png"
@@ -53,6 +53,12 @@ describe('Twitch channel result component', () => {
     render(<TwitchChannelResult channelData={testData} />)
     const name = screen.getByText('Loserfruit');
     expect(name).toBeInTheDocument()
+  });
+
+  it('Includes channel game name (current game)', () => {
+    render(<TwitchChannelResult channelData={testData} />)
+    const game = screen.getByText('Just Chatting');
+    expect(game).toBeInTheDocument()
   });
 
   it('Includes LIVE indicator for currently streaming channel', () => {

--- a/__tests__/componentTests/TwitchChannelResult.test.tsx
+++ b/__tests__/componentTests/TwitchChannelResult.test.tsx
@@ -1,33 +1,45 @@
 import { render, screen } from '@testing-library/react'
-import { HelixChannelSearchResultData } from '@twurple/api/lib/api/helix/search/HelixChannelSearchResult';
 import TwitchChannelResult from '../../components/TwitchChannelResult';
+import { HelixChannelSearchResult } from '@twurple/api/lib/api/helix/search/HelixChannelSearchResult';
 
-const testData: HelixChannelSearchResultData = {
-  broadcaster_language: "en",
-  broadcaster_login: "loserfruit",
-  display_name: "Loserfruit",
-  game_id: "498000",
-  game_name: "House Flipper",
+const testData: HelixChannelSearchResult = {
+  _client: {},
+  // @ts-expect-error exact getUser implementation not needed in these tests
+  getUser: jest.fn,
+  // @ts-expect-error exact getGame implementation not needed in these tests
+  getGame: jest.fn,
+  // @ts-expect-error exact getTags implementation not needed in these tests
+  getTags: jest.fn,
+  displayName: "loserfruit",
+  gameId: "509658",
+  gameName: "Just Chatting",
   id: "41245072",
-  is_live: false,
-  tag_ids: [],
-  thumbnail_url: "https://static-cdn.jtvnw.net/jtv_user_pictures/fd17325a-7dc2-46c6-8617-e90ec259501c-profile_image-300x300.png",
-  title: "loserfruit",
-  started_at: ""
+  isLive: false,
+  language: "en",
+  name: "smasherger",
+  startDate: null,
+  tagIds: [],
+  thumbnailUrl: "https://static-cdn.jtvnw.net/jtv_user_pictures/fd17325a-7dc2-46c6-8617-e90ec259501c-profile_image-300x300.png"
 }
 
-const testDataLive: HelixChannelSearchResultData = {
-  broadcaster_language: "en",
-  broadcaster_login: "loserfruit",
-  display_name: "Loserfruit",
-  game_id: "498000",
-  game_name: "House Flipper",
+const testDataLive: HelixChannelSearchResult = {
+  _client: {},
+  // @ts-expect-error exact getUser implementation not needed in these tests
+  getUser: jest.fn,
+  // @ts-expect-error exact getGame implementation not needed in these tests
+  getGame: jest.fn,
+  // @ts-expect-error exact getTags implementation not needed in these tests
+  getTags: jest.fn,
+  displayName: "loserfruit",
+  gameId: "509658",
+  gameName: "Just Chatting",
   id: "41245072",
-  is_live: true,
-  tag_ids: [],
-  thumbnail_url: "https://static-cdn.jtvnw.net/jtv_user_pictures/fd17325a-7dc2-46c6-8617-e90ec259501c-profile_image-300x300.png",
-  title: "loserfruit",
-  started_at: ""
+  isLive: true,
+  language: "en",
+  name: "smasherger",
+  startDate: null,
+  tagIds: [],
+  thumbnailUrl: "https://static-cdn.jtvnw.net/jtv_user_pictures/fd17325a-7dc2-46c6-8617-e90ec259501c-profile_image-300x300.png"
 }
 
 describe('Twitch channel result component', () => {

--- a/__tests__/componentTests/TwitchChannelResult.test.tsx
+++ b/__tests__/componentTests/TwitchChannelResult.test.tsx
@@ -1,6 +1,13 @@
 import { render, screen } from '@testing-library/react'
 import TwitchChannelResult from '../../components/TwitchChannelResult';
 import { HelixChannelSearchResult } from '@twurple/api/lib/api/helix/search/HelixChannelSearchResult';
+// jest.setup.js
+
+import { setConfig } from 'next/config'
+import config from '../../next.config'
+
+// Make sure you can use "publicRuntimeConfig" within tests.
+setConfig(config)
 
 const testData: HelixChannelSearchResult = {
   _client: {},

--- a/__tests__/componentTests/TwitchChannelResult.test.tsx
+++ b/__tests__/componentTests/TwitchChannelResult.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react'
+import { HelixChannelSearchResultData } from '@twurple/api/lib/api/helix/search/HelixChannelSearchResult';
+import TwitchChannelResult from '../../components/TwitchChannelResult';
+
+const testData: HelixChannelSearchResultData = {
+  broadcaster_language: "en",
+  broadcaster_login: "loserfruit",
+  display_name: "Loserfruit",
+  game_id: "498000",
+  game_name: "House Flipper",
+  id: "41245072",
+  is_live: false,
+  tag_ids: [],
+  thumbnail_url: "https://static-cdn.jtvnw.net/jtv_user_pictures/fd17325a-7dc2-46c6-8617-e90ec259501c-profile_image-300x300.png",
+  title: "loserfruit",
+  started_at: ""
+}
+
+const testDataLive: HelixChannelSearchResultData = {
+  broadcaster_language: "en",
+  broadcaster_login: "loserfruit",
+  display_name: "Loserfruit",
+  game_id: "498000",
+  game_name: "House Flipper",
+  id: "41245072",
+  is_live: true,
+  tag_ids: [],
+  thumbnail_url: "https://static-cdn.jtvnw.net/jtv_user_pictures/fd17325a-7dc2-46c6-8617-e90ec259501c-profile_image-300x300.png",
+  title: "loserfruit",
+  started_at: ""
+}
+
+describe('Twitch channel result component', () => {
+  it('Includes channel thumbnail', () => {
+    render(<TwitchChannelResult channelData={testData} />)
+    const thumbnail = screen.getByRole('img');
+    expect(thumbnail).toBeInTheDocument()
+  });
+
+  it('Includes channel name', () => {
+    render(<TwitchChannelResult channelData={testData} />)
+    const name = screen.getByText('Loserfruit');
+    expect(name).toBeInTheDocument()
+  });
+
+  it('Includes LIVE indicator for currently streaming channel', () => {
+    render(<TwitchChannelResult channelData={testDataLive} />)
+    const live = screen.getByText('LIVE');
+    expect(live).toBeInTheDocument()
+  });
+
+  it('Does not show LIVE indicator for currently offline channel', () => {
+    render(<TwitchChannelResult channelData={testData} />)
+    const live = screen.getByText('LIVE');
+    expect(live).not.toBeInTheDocument()
+  });
+
+  // Unsure if this is to be included
+  it('Includes active subscribe button (if not yet subscribed)', () => {
+    render(<TwitchChannelResult channelData={testData} />)
+    const subscribe = screen.getByRole('button', { name: /subscribe/i });
+    expect(subscribe).toBeInTheDocument()
+  });
+
+  it('Includes "unsubscribe" button (if already subscribed)', () => {
+    render(<TwitchChannelResult channelData={testData} />)
+    const unsubscribe = screen.getByRole('button', { name: /unsubscribe/i });
+    expect(unsubscribe).toBeInTheDocument()
+  });
+})

--- a/__tests__/componentTests/YouTubeChannelResult.test.tsx
+++ b/__tests__/componentTests/YouTubeChannelResult.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { YouTubeSearchResultSnippet } from 'types/youtubeAPITypes';
+import YouTubeChannelResult from '../../components/YouTubeChannelResult';
+
+const testData: YouTubeSearchResultSnippet = {
+  publishedAt: "2015-08-26T11:12:55Z",
+  channelId: "UC_qVvdPdMIZDEc6zdj06ilA",
+  title: "Smash",
+  description: "Hi , I'm Smash. I upload funny .io games. Most of them are funny moments and trolling. Most of the time I upload Agar.io, Slither.io ...",
+  thumbnails: {
+    default: {
+      url: "https://yt3.ggpht.com/ytc/AKedOLT_seyyy6UoovylO6PfSQ9WYy3WLh9CF_g4KlgZvw=s88-c-k-c0xffffffff-no-rj-mo"
+    },
+    medium: {
+      url: "https://yt3.ggpht.com/ytc/AKedOLT_seyyy6UoovylO6PfSQ9WYy3WLh9CF_g4KlgZvw=s240-c-k-c0xffffffff-no-rj-mo"
+    },
+    high: {
+      url: "https://yt3.ggpht.com/ytc/AKedOLT_seyyy6UoovylO6PfSQ9WYy3WLh9CF_g4KlgZvw=s800-c-k-c0xffffffff-no-rj-mo"
+    }
+  },
+  channelTitle: "Smash",
+  liveBroadcastContent: "none",
+  publishTime: "2015-08-26T11:12:55Z"
+}
+
+describe('YouTube channel result component', () => {
+  // This tests for small thumbnail specifically
+  it('Includes channel thumbnail', () => {
+    render(<YouTubeChannelResult channelData={testData} />)
+    const thumbnail = screen.getByRole('img');
+    expect(thumbnail).toHaveAttribute('src', 'https://yt3.ggpht.com/ytc/AKedOLT_seyyy6UoovylO6PfSQ9WYy3WLh9CF_g4KlgZvw=s800-c-k-c0xffffffff-no-rj-mo');
+    expect(thumbnail).toBeInTheDocument();
+  });
+
+  it('Includes channel name', () => {
+    render(<YouTubeChannelResult channelData={testData} />)
+    const name = screen.getByText('Smash');
+    expect(name).toBeInTheDocument()
+  });
+
+  it('Includes channel description', () => {
+    render(<YouTubeChannelResult channelData={testData} />)
+    const description = screen.getByText("Hi , I'm Smash. I upload funny .io games. Most of them are funny moments and trolling. Most of the time I upload Agar.io, Slither.io ...");
+    expect(description).toBeInTheDocument()
+  });
+
+  // Unsure if this is to be included
+  it('Includes active subscribe button (if not yet subscribed)', () => {
+    render(<YouTubeChannelResult channelData={testData} />)
+    const subscribe = screen.getByRole('button', { name: /subscribe/i });
+    expect(subscribe).toBeInTheDocument()
+  });
+
+  it('Includes "unsubscribe" button (if already subscribed)', () => {
+    render(<YouTubeChannelResult channelData={testData} />)
+    const unsubscribe = screen.getByRole('button', { name: /unsubscribe/i });
+    expect(unsubscribe).toBeInTheDocument()
+  });
+})

--- a/__tests__/componentTests/YouTubeChannelResult.test.tsx
+++ b/__tests__/componentTests/YouTubeChannelResult.test.tsx
@@ -24,11 +24,10 @@ const testData: YouTubeSearchResultSnippet = {
 }
 
 describe('YouTube channel result component', () => {
-  // This tests for small thumbnail specifically
+  // This tests for default thumbnail specifically
   it('Includes channel thumbnail', () => {
     render(<YouTubeChannelResult channelData={testData} />)
     const thumbnail = screen.getByRole('img');
-    expect(thumbnail).toHaveAttribute('src', 'https://yt3.ggpht.com/ytc/AKedOLT_seyyy6UoovylO6PfSQ9WYy3WLh9CF_g4KlgZvw=s800-c-k-c0xffffffff-no-rj-mo');
     expect(thumbnail).toBeInTheDocument();
   });
 

--- a/components/TwitchChannelResult.tsx
+++ b/components/TwitchChannelResult.tsx
@@ -1,4 +1,5 @@
 import { HelixChannelSearchResultData } from "@twurple/api/lib/api/helix/search/HelixChannelSearchResult";
+import Image from "next/image";
 
 // TWITCH Channel
 const twitchChannel = {
@@ -21,7 +22,19 @@ interface TwitchChannelResultProps {
 
 const ChannelResult = ({ channelData }: TwitchChannelResultProps) => {
   return (
-    <div>Twitch Channel Data</div>
+    <div>
+      <div>
+        <Image src={channelData.thumbnail_url} alt={`${channelData.display_name} channel thumbnail`} layout="fill" />
+      </div>
+      <div>
+        <h3>{channelData.display_name}</h3>
+        {channelData.is_live && (
+          <span>
+            LIVE
+          </span>
+        )}
+      </div>
+    </div>
   )
 }
 

--- a/components/TwitchChannelResult.tsx
+++ b/components/TwitchChannelResult.tsx
@@ -1,5 +1,5 @@
-import { HelixChannelSearchResultData } from "@twurple/api/lib/api/helix/search/HelixChannelSearchResult";
 import Image from "next/image";
+import { HelixChannelSearchResult } from "@twurple/api/lib/api/helix/search/HelixChannelSearchResult";
 
 // TWITCH Channel
 const twitchChannel = {
@@ -17,18 +17,18 @@ const twitchChannel = {
 }
 
 interface TwitchChannelResultProps {
-  channelData: HelixChannelSearchResultData;
+  channelData: HelixChannelSearchResult;
 }
 
 const ChannelResult = ({ channelData }: TwitchChannelResultProps) => {
   return (
     <div>
       <div>
-        <Image src={channelData.thumbnail_url} alt={`${channelData.display_name} channel thumbnail`} layout="fill" />
+        <Image src={channelData.thumbnailUrl} alt={`${channelData.displayName} channel thumbnail`} layout="fill" />
       </div>
       <div>
-        <h3>{channelData.display_name}</h3>
-        {channelData.is_live && (
+        <h3>{channelData.displayName}</h3>
+        {channelData.isLive && (
           <span>
             LIVE
           </span>

--- a/components/TwitchChannelResult.tsx
+++ b/components/TwitchChannelResult.tsx
@@ -1,21 +1,6 @@
 import Image from "next/image";
 import { HelixChannelSearchResult } from "@twurple/api/lib/api/helix/search/HelixChannelSearchResult";
 
-// TWITCH Channel
-const twitchChannel = {
-  "broadcaster_language": "en",
-  "broadcaster_login": "loserfruit",
-  "display_name": "Loserfruit",
-  "game_id": "498000",
-  "game_name": "House Flipper",
-  "id": "41245072",
-  "is_live": false,
-  "tags_ids": [],
-  "thumbnail_url": "https://static-cdn.jtvnw.net/jtv_user_pictures/fd17325a-7dc2-46c6-8617-e90ec259501c-profile_image-300x300.png",
-  "title": "loserfruit",
-  "started_at": ""
-}
-
 interface TwitchChannelResultProps {
   channelData: HelixChannelSearchResult;
 }
@@ -33,6 +18,7 @@ const ChannelResult = ({ channelData }: TwitchChannelResultProps) => {
             LIVE
           </span>
         )}
+        <div>{channelData.gameName}</div>
       </div>
     </div>
   )

--- a/components/TwitchChannelResult.tsx
+++ b/components/TwitchChannelResult.tsx
@@ -24,7 +24,7 @@ const ChannelResult = ({ channelData }: TwitchChannelResultProps) => {
   return (
     <div>
       <div>
-        <Image src={channelData.thumbnailUrl} alt={`${channelData.displayName} channel thumbnail`} layout="fill" />
+        <Image src={channelData.thumbnailUrl} alt={`${channelData.displayName} channel thumbnail`} height={100} width={100} />
       </div>
       <div>
         <h3>{channelData.displayName}</h3>

--- a/components/TwitchChannelResult.tsx
+++ b/components/TwitchChannelResult.tsx
@@ -1,0 +1,28 @@
+import { HelixChannelSearchResult } from "@twurple/api/lib";
+
+// TWITCH Channel
+const twitchChannel = {
+  "broadcaster_language": "en",
+  "broadcaster_login": "loserfruit",
+  "display_name": "Loserfruit",
+  "game_id": "498000",
+  "game_name": "House Flipper",
+  "id": "41245072",
+  "is_live": false,
+  "tags_ids": [],
+  "thumbnail_url": "https://static-cdn.jtvnw.net/jtv_user_pictures/fd17325a-7dc2-46c6-8617-e90ec259501c-profile_image-300x300.png",
+  "title": "loserfruit",
+  "started_at": ""
+}
+
+interface TwitchChannelResultProps {
+  channelData: HelixChannelSearchResult;
+}
+
+const ChannelResult = ({ channelData }: TwitchChannelResultProps) => {
+  return (
+    <div>Twitch Channel Data</div>
+  )
+}
+
+export default ChannelResult

--- a/components/TwitchChannelResult.tsx
+++ b/components/TwitchChannelResult.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { HelixChannelSearchResult } from "@twurple/api/lib/api/helix/search/HelixChannelSearchResult";
+import styles from '../styles/componentStyles/TwitchSearchResult.module.css'
 
 interface TwitchChannelResultProps {
   channelData: HelixChannelSearchResult;
@@ -7,18 +8,18 @@ interface TwitchChannelResultProps {
 
 const ChannelResult = ({ channelData }: TwitchChannelResultProps) => {
   return (
-    <div>
-      <div>
-        <Image src={channelData.thumbnailUrl} alt={`${channelData.displayName} channel thumbnail`} height={100} width={100} />
-      </div>
-      <div>
-        <h3>{channelData.displayName}</h3>
+    <div className={styles.channel}>
+      <div className={styles.imgContainer}>
+        <Image src={channelData.thumbnailUrl} alt={`${channelData.displayName} channel thumbnail`} height={100} width={100} className={styles.thumbnail} layout="fixed" />
         {channelData.isLive && (
-          <span>
+          <span className={styles.live}>
             LIVE
           </span>
         )}
-        <div>{channelData.gameName}</div>
+      </div>
+      <div className={styles.channelText}>
+        <h3 className={styles.channelTitle}>{channelData.displayName}</h3>
+        <p className={styles.game}>{channelData.gameName}</p>
       </div>
     </div>
   )

--- a/components/TwitchChannelResult.tsx
+++ b/components/TwitchChannelResult.tsx
@@ -1,4 +1,4 @@
-import { HelixChannelSearchResult } from "@twurple/api/lib";
+import { HelixChannelSearchResultData } from "@twurple/api/lib/api/helix/search/HelixChannelSearchResult";
 
 // TWITCH Channel
 const twitchChannel = {
@@ -16,7 +16,7 @@ const twitchChannel = {
 }
 
 interface TwitchChannelResultProps {
-  channelData: HelixChannelSearchResult;
+  channelData: HelixChannelSearchResultData;
 }
 
 const ChannelResult = ({ channelData }: TwitchChannelResultProps) => {

--- a/components/YouTubeChannelResult.tsx
+++ b/components/YouTubeChannelResult.tsx
@@ -1,34 +1,5 @@
 import { YouTubeSearchResultSnippet } from "types/youtubeAPITypes"
 
-const youtubeChannel = {
-  "kind": "youtube#searchResult",
-  "etag": "pemsyJ8zaYeHl1xMbMMX8H-jk0g",
-  "id": {
-    "kind": "youtube#channel",
-    "channelId": "UC_qVvdPdMIZDEc6zdj06ilA"
-  },
-  "snippet": {
-    "publishedAt": "2015-08-26T11:12:55Z",
-    "channelId": "UC_qVvdPdMIZDEc6zdj06ilA",
-    "title": "Smash",
-    "description": "Hi , I'm Smash. I upload funny .io games. Most of them are funny moments and trolling. Most of the time I upload Agar.io, Slither.io ...",
-    "thumbnails": {
-      "default": {
-        "url": "https://yt3.ggpht.com/ytc/AKedOLT_seyyy6UoovylO6PfSQ9WYy3WLh9CF_g4KlgZvw=s88-c-k-c0xffffffff-no-rj-mo"
-      },
-      "medium": {
-        "url": "https://yt3.ggpht.com/ytc/AKedOLT_seyyy6UoovylO6PfSQ9WYy3WLh9CF_g4KlgZvw=s240-c-k-c0xffffffff-no-rj-mo"
-      },
-      "high": {
-        "url": "https://yt3.ggpht.com/ytc/AKedOLT_seyyy6UoovylO6PfSQ9WYy3WLh9CF_g4KlgZvw=s800-c-k-c0xffffffff-no-rj-mo"
-      }
-    },
-    "channelTitle": "Smash",
-    "liveBroadcastContent": "none",
-    "publishTime": "2015-08-26T11:12:55Z"
-  }
-}
-
 interface YouTubeChannelResultProps {
   channelData: YouTubeSearchResultSnippet;
 }

--- a/components/YouTubeChannelResult.tsx
+++ b/components/YouTubeChannelResult.tsx
@@ -1,5 +1,6 @@
 import { YouTubeSearchResultSnippet } from "types/youtubeAPITypes";
-import Image from 'next/image'
+import Image from 'next/image';
+import styles from '../styles/componentStyles/YouTubeSearchResult.module.css'
 
 interface YouTubeChannelResultProps {
   channelData: YouTubeSearchResultSnippet;
@@ -7,13 +8,11 @@ interface YouTubeChannelResultProps {
 
 const YouTubeChannelResult = ({ channelData }: YouTubeChannelResultProps) => {
   return (
-    <div>
-      <div>
-        <Image src={channelData.thumbnails.default?.url} alt={`${channelData.channelTitle} channel thumbnail`} height={100} width={100} />
-      </div>
-      <div>
-        <h3>{channelData.channelTitle}</h3>
-        <p>{channelData.description}</p>
+    <div className={styles.channel}>
+      <Image src={channelData.thumbnails.medium.url} alt={`${channelData.channelTitle} channel thumbnail`} height={100} width={100} className={styles.thumbnail} layout="raw" />
+      <div className={styles.channelText}>
+        <h3 className={styles.channelTitle}>{channelData.channelTitle}</h3>
+        <p className={styles.description}>{channelData.description}</p>
       </div>
     </div>
   )

--- a/components/YouTubeChannelResult.tsx
+++ b/components/YouTubeChannelResult.tsx
@@ -9,7 +9,9 @@ interface YouTubeChannelResultProps {
 const YouTubeChannelResult = ({ channelData }: YouTubeChannelResultProps) => {
   return (
     <div className={styles.channel}>
-      <Image src={channelData.thumbnails.medium.url} alt={`${channelData.channelTitle} channel thumbnail`} height={100} width={100} className={styles.thumbnail} layout="raw" />
+      <div>
+        <Image src={channelData.thumbnails.medium.url} alt={`${channelData.channelTitle} channel thumbnail`} height={100} width={100} className={styles.thumbnail} layout="fixed" />
+      </div>
       <div className={styles.channelText}>
         <h3 className={styles.channelTitle}>{channelData.channelTitle}</h3>
         <p className={styles.description}>{channelData.description}</p>

--- a/components/YouTubeChannelResult.tsx
+++ b/components/YouTubeChannelResult.tsx
@@ -1,0 +1,42 @@
+import { YouTubeSearchResultSnippet } from "types/youtubeAPITypes"
+
+const youtubeChannel = {
+  "kind": "youtube#searchResult",
+  "etag": "pemsyJ8zaYeHl1xMbMMX8H-jk0g",
+  "id": {
+    "kind": "youtube#channel",
+    "channelId": "UC_qVvdPdMIZDEc6zdj06ilA"
+  },
+  "snippet": {
+    "publishedAt": "2015-08-26T11:12:55Z",
+    "channelId": "UC_qVvdPdMIZDEc6zdj06ilA",
+    "title": "Smash",
+    "description": "Hi , I'm Smash. I upload funny .io games. Most of them are funny moments and trolling. Most of the time I upload Agar.io, Slither.io ...",
+    "thumbnails": {
+      "default": {
+        "url": "https://yt3.ggpht.com/ytc/AKedOLT_seyyy6UoovylO6PfSQ9WYy3WLh9CF_g4KlgZvw=s88-c-k-c0xffffffff-no-rj-mo"
+      },
+      "medium": {
+        "url": "https://yt3.ggpht.com/ytc/AKedOLT_seyyy6UoovylO6PfSQ9WYy3WLh9CF_g4KlgZvw=s240-c-k-c0xffffffff-no-rj-mo"
+      },
+      "high": {
+        "url": "https://yt3.ggpht.com/ytc/AKedOLT_seyyy6UoovylO6PfSQ9WYy3WLh9CF_g4KlgZvw=s800-c-k-c0xffffffff-no-rj-mo"
+      }
+    },
+    "channelTitle": "Smash",
+    "liveBroadcastContent": "none",
+    "publishTime": "2015-08-26T11:12:55Z"
+  }
+}
+
+interface YouTubeChannelResultProps {
+  channelData: YouTubeSearchResultSnippet;
+}
+
+const YouTubeChannelResult = ({ channelData }: YouTubeChannelResultProps) => {
+  return (
+    <div>YouTube Channel Result</div>
+  )
+}
+
+export default YouTubeChannelResult

--- a/components/YouTubeChannelResult.tsx
+++ b/components/YouTubeChannelResult.tsx
@@ -9,7 +9,7 @@ const YouTubeChannelResult = ({ channelData }: YouTubeChannelResultProps) => {
   return (
     <div>
       <div>
-        <Image src={channelData.thumbnails.default?.url} alt={`${channelData.channelTitle} channel thumbnail`} layout="fill" />
+        <Image src={channelData.thumbnails.default?.url} alt={`${channelData.channelTitle} channel thumbnail`} height={100} width={100} />
       </div>
       <div>
         <h3>{channelData.channelTitle}</h3>

--- a/components/YouTubeChannelResult.tsx
+++ b/components/YouTubeChannelResult.tsx
@@ -1,4 +1,5 @@
-import { YouTubeSearchResultSnippet } from "types/youtubeAPITypes"
+import { YouTubeSearchResultSnippet } from "types/youtubeAPITypes";
+import Image from 'next/image'
 
 interface YouTubeChannelResultProps {
   channelData: YouTubeSearchResultSnippet;
@@ -6,7 +7,15 @@ interface YouTubeChannelResultProps {
 
 const YouTubeChannelResult = ({ channelData }: YouTubeChannelResultProps) => {
   return (
-    <div>YouTube Channel Result</div>
+    <div>
+      <div>
+        <Image src={channelData.thumbnails.default?.url} alt={`${channelData.channelTitle} channel thumbnail`} layout="fill" />
+      </div>
+      <div>
+        <h3>{channelData.channelTitle}</h3>
+        <p>{channelData.description}</p>
+      </div>
+    </div>
   )
 }
 

--- a/hooks/useYoutubeSearch.ts
+++ b/hooks/useYoutubeSearch.ts
@@ -1,6 +1,6 @@
 import { useGapiContext } from "../context/GapiContext";
 import { useQuery } from "react-query";
-import { SearchListResponse } from "types/youtubeAPITypes";
+import { YouTubeSearchListResponse } from "types/youtubeAPITypes";
 
 // searchType should be a comma separated list of one or more of channels, playlist, and video (e.g. "channel,video")
 // conditions specify any additional criteria that must evaluate to true before the query is executed
@@ -28,7 +28,7 @@ export const useYouTubeSearch = (searchQuery: string, searchType: string, condit
       }
     });
 
-    return response.result as SearchListResponse;
+    return response.result as YouTubeSearchListResponse;
   }, {
     // Check for additional conditions before formulating enabled expression. gapiClientReady must always be present, as must enableApi
     enabled: (conditions !== undefined) ? (conditions && gapiClientReady && enableApi) : (gapiClientReady && enableApi)

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  images: {
+    domains: ['static-cdn.jtvnw.net'],
+  },
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   images: {
-    domains: ['static-cdn.jtvnw.net'],
+    domains: ['static-cdn.jtvnw.net', 'yt3.ggpht.com'],
   },
 }

--- a/next.config.js
+++ b/next.config.js
@@ -2,4 +2,5 @@ module.exports = {
   images: {
     domains: ['static-cdn.jtvnw.net', 'yt3.ggpht.com'],
   },
+  experimental: { images: { layoutRaw: true } }
 }

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -753,10 +753,10 @@ const Search = () => {
     isValidQuery(UrlQuery)
   );
 
-  // const { isLoading: isTwitchLoading, isError: isTwitchError, data: twitchData, error: twitchError, isIdle: isTwitchIdle } = useTwitchSearch(
-  //   sanitiseQuery(UrlQuery),
-  //   isValidQuery(UrlQuery)
-  // );
+  const { isLoading: isTwitchLoading, isError: isTwitchError, data: twitchData, error: twitchError, isIdle: isTwitchIdle } = useTwitchSearch(
+    sanitiseQuery(UrlQuery),
+    isValidQuery(UrlQuery)
+  );
 
   useEffect(() => {
     if (data) {
@@ -795,13 +795,13 @@ const Search = () => {
       <div>You searched for {UrlQuery.searchQuery}</div>
       {/* {isTwitchLoading && <div>Twitch loading...</div>} */}
       {isLoading && <div>YouTube loading...</div>}
-      {/* {twitchData && (
+      {twitchData && (
         <>
           {twitchData.data.map((channel) => (
             <TwitchChannelResult key={channel.id} channelData={channel} />
           ))}
         </>
-      )} */}
+      )}
       {testData && (
         <>
           {testData.items.map((channel) => (

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -6,6 +6,719 @@ import { useYouTubeSearch } from "../hooks/useYoutubeSearch";
 import TwitchChannelResult from '../components/TwitchChannelResult'
 import YouTubeChannelResult from "@/components/YouTubeChannelResult";
 
+const testData = {
+  "kind": "youtube#searchListResponse",
+  "etag": "lWVZc5USbrxXlJdsB9Zv2nAgmCk",
+  "nextPageToken": "CBkQAA",
+  "regionCode": "AU",
+  "pageInfo": {
+    "totalResults": 1000000,
+    "resultsPerPage": 25
+  },
+  "items": [
+    {
+      "kind": "youtube#searchResult",
+      "etag": "CHYY7VlBkyJiSXtbGbyn9k5LTA0",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UC6zzlBIwNS9GJZZ3rBx_WhQ"
+      },
+      "snippet": {
+        "publishedAt": "2020-07-25T21:28:02Z",
+        "channelId": "UC6zzlBIwNS9GJZZ3rBx_WhQ",
+        "title": "Hudson's Playground Gaming",
+        "description": "Hudson's Playground Gaming is a channel me and Hudson decided to make featuring family friendly gaming! We will play farming ...",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLRerYD1Y1v2FFTpBa_vSsjto8CebOgshjA78hN0=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLRerYD1Y1v2FFTpBa_vSsjto8CebOgshjA78hN0=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLRerYD1Y1v2FFTpBa_vSsjto8CebOgshjA78hN0=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "Hudson's Playground Gaming",
+        "liveBroadcastContent": "upcoming",
+        "publishTime": "2020-07-25T21:28:02Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "_8PMvFXEjIvgjkSMLg0YC3dP7dw",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCIPPMRA040LQr5QPyJEbmXA"
+      },
+      "snippet": {
+        "publishedAt": "2020-04-07T18:46:13Z",
+        "channelId": "UCIPPMRA040LQr5QPyJEbmXA",
+        "title": "MrBeast Gaming",
+        "description": "MrBeast Gaming - SUBSCRIBE OR ELSE.",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSg4oAq1Fk3S0C3J7InJOspNGSB3_-USBu3gS8iLg=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSg4oAq1Fk3S0C3J7InJOspNGSB3_-USBu3gS8iLg=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSg4oAq1Fk3S0C3J7InJOspNGSB3_-USBu3gS8iLg=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "MrBeast Gaming",
+        "liveBroadcastContent": "none",
+        "publishTime": "2020-04-07T18:46:13Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "L3rI0Bh1SzXUttcdIO4fzl-sA5I",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCWcly5Teks2uSNsF5hRFNNg"
+      },
+      "snippet": {
+        "publishedAt": "2019-03-04T10:12:37Z",
+        "channelId": "UCWcly5Teks2uSNsF5hRFNNg",
+        "title": "Norris Nuts Gaming",
+        "description": "Norris Nuts Gaming Channel. Doing gaming the Norris Nuts way! Fun quirky family friendly from Sabre, Sockie, Biggy Naz, Disco ...",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLRBogdQ5WJfnp_AWwFHujjza5gt8LhAkatAT7XTKQ=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLRBogdQ5WJfnp_AWwFHujjza5gt8LhAkatAT7XTKQ=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLRBogdQ5WJfnp_AWwFHujjza5gt8LhAkatAT7XTKQ=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "Norris Nuts Gaming",
+        "liveBroadcastContent": "none",
+        "publishTime": "2019-03-04T10:12:37Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "8-z32_WOJ4Kn0Dsmls-ckpRytMo",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UC5ClPDdbfTUYNSsjXpu5n3A"
+      },
+      "snippet": {
+        "publishedAt": "2019-06-20T20:58:59Z",
+        "channelId": "UC5ClPDdbfTUYNSsjXpu5n3A",
+        "title": "Sopo Squad Gaming",
+        "description": "Roblox gaming family!! It's the Sopo Squad! Watch Dad, Mike (mikedrop937), daughter Cammy (CammyxBoba), Mom, Lizzy ...",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/Xjbs3T249dYW6UblhzFOyt4Ydtv5hzUlIYNIhBvpr5qjRSDGtqP-JgsYAYM23CFpnDEWwceB=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/Xjbs3T249dYW6UblhzFOyt4Ydtv5hzUlIYNIhBvpr5qjRSDGtqP-JgsYAYM23CFpnDEWwceB=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/Xjbs3T249dYW6UblhzFOyt4Ydtv5hzUlIYNIhBvpr5qjRSDGtqP-JgsYAYM23CFpnDEWwceB=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "Sopo Squad Gaming",
+        "liveBroadcastContent": "none",
+        "publishTime": "2019-06-20T20:58:59Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "op56ep99nucn5cw2WJj6Ob0imAA",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCTRohxutThBffdcP3H6O0Zg"
+      },
+      "snippet": {
+        "publishedAt": "2016-05-02T17:52:15Z",
+        "channelId": "UCTRohxutThBffdcP3H6O0Zg",
+        "title": "Indigo Gaming",
+        "description": "Insightful game analysis, reviews and retrospectives with an emphasis on historical importance and their impact on the industry.",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLTECHjuKHEzOAYJxT8PzxhcdycgEtfoTVNb-pP1Bg=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLTECHjuKHEzOAYJxT8PzxhcdycgEtfoTVNb-pP1Bg=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLTECHjuKHEzOAYJxT8PzxhcdycgEtfoTVNb-pP1Bg=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "Indigo Gaming",
+        "liveBroadcastContent": "upcoming",
+        "publishTime": "2016-05-02T17:52:15Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "MpbexPuXIRyV9bKNCk2paEdQ9rg",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCvO9Xk3bheuxEemvknCj72g"
+      },
+      "snippet": {
+        "publishedAt": "2015-09-22T11:05:15Z",
+        "channelId": "UCvO9Xk3bheuxEemvknCj72g",
+        "title": "WhatCulture Gaming",
+        "description": "",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/kqb1YIEVKcjNLhDseGoltwKv_b7G1svno6aiw6wuAVn-IgfgebL64_6dcJTB2JVAmGhgyRixpA=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/kqb1YIEVKcjNLhDseGoltwKv_b7G1svno6aiw6wuAVn-IgfgebL64_6dcJTB2JVAmGhgyRixpA=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/kqb1YIEVKcjNLhDseGoltwKv_b7G1svno6aiw6wuAVn-IgfgebL64_6dcJTB2JVAmGhgyRixpA=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "WhatCulture Gaming",
+        "liveBroadcastContent": "none",
+        "publishTime": "2015-09-22T11:05:15Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "rQD88_GBUE94A-rAnBrvhAThOqI",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCugqjlk-tkE_uZnG0tDbQyg"
+      },
+      "snippet": {
+        "publishedAt": "2016-05-04T04:10:56Z",
+        "channelId": "UCugqjlk-tkE_uZnG0tDbQyg",
+        "title": "Wow Such Gaming",
+        "description": "Why You Wouldn't Survive, Zombie Sins, Zombie movie reviews and sometimes Left 4 Dead speed runs. STAY WOW.",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSU27KiMR1ZwceURHP4lFhICpCXWvqUEFUn_cP1EA=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSU27KiMR1ZwceURHP4lFhICpCXWvqUEFUn_cP1EA=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSU27KiMR1ZwceURHP4lFhICpCXWvqUEFUn_cP1EA=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "Wow Such Gaming",
+        "liveBroadcastContent": "upcoming",
+        "publishTime": "2016-05-04T04:10:56Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "cpap4co07Br44HUxB_fZN5BImiQ",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCWp3_e0cQvBHVpb_pTge5FQ"
+      },
+      "snippet": {
+        "publishedAt": "2017-09-12T01:14:53Z",
+        "channelId": "UCWp3_e0cQvBHVpb_pTge5FQ",
+        "title": "Sam Tabor Gaming",
+        "description": "Hey! I'm Sam. A lot of you may know me from my skateboarding videos, but LITTLE DID YOU KNOW I love video games too.",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLQOBLFXie59f5kIhhD9eVcbnRRc4rJbW8WRbhTelw=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLQOBLFXie59f5kIhhD9eVcbnRRc4rJbW8WRbhTelw=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLQOBLFXie59f5kIhhD9eVcbnRRc4rJbW8WRbhTelw=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "Sam Tabor Gaming",
+        "liveBroadcastContent": "upcoming",
+        "publishTime": "2017-09-12T01:14:53Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "kldWZ3ZBUA9J57RgyCqUJWHwVaY",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UC7BE9QNju4NMgDDL75-uj2A"
+      },
+      "snippet": {
+        "publishedAt": "2020-04-22T21:03:53Z",
+        "channelId": "UC7BE9QNju4NMgDDL75-uj2A",
+        "title": "XOXO Gaming",
+        "description": "Hi! I'm Addy from Tic Tac Toy and welcome to my official gaming channel. I love to play Roblox with my sister Maya and our XOXO ...",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLTBC3N2GQ-J464Yk6cdGKDMK17IY92HVWmWieFW=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLTBC3N2GQ-J464Yk6cdGKDMK17IY92HVWmWieFW=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLTBC3N2GQ-J464Yk6cdGKDMK17IY92HVWmWieFW=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "XOXO Gaming",
+        "liveBroadcastContent": "none",
+        "publishTime": "2020-04-22T21:03:53Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "nyafbZIGRguqFLn5p2DhvvHren4",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UC85aYbNSFjsJdxfpxgQr8tA"
+      },
+      "snippet": {
+        "publishedAt": "2014-02-04T20:26:13Z",
+        "channelId": "UC85aYbNSFjsJdxfpxgQr8tA",
+        "title": "Judo Sloth Gaming",
+        "description": "A Clash of Clans based channel focusing on helping you improve your gameplay. You will see a variety of content from guides to ...",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLQjWTCn83fNAmDgzmnIKeBLjdqt3_xxUQ-Ompk98g=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLQjWTCn83fNAmDgzmnIKeBLjdqt3_xxUQ-Ompk98g=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLQjWTCn83fNAmDgzmnIKeBLjdqt3_xxUQ-Ompk98g=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "Judo Sloth Gaming",
+        "liveBroadcastContent": "upcoming",
+        "publishTime": "2014-02-04T20:26:13Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "2Cxpm0pPBB-4_UL6gPKXtEVZcwo",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCnbvPS_rXp4PC21PG2k1UVg"
+      },
+      "snippet": {
+        "publishedAt": "2006-07-17T15:22:55Z",
+        "channelId": "UCnbvPS_rXp4PC21PG2k1UVg",
+        "title": "Gaming Historian",
+        "description": "The Gaming Historian is a documentary series all about the history of video games. The show is researched, written, edited, and ...",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSD_e-_nxZmHo6xDyw91rfwpKS5BzyVH4Z31jXOxw=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSD_e-_nxZmHo6xDyw91rfwpKS5BzyVH4Z31jXOxw=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSD_e-_nxZmHo6xDyw91rfwpKS5BzyVH4Z31jXOxw=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "Gaming Historian",
+        "liveBroadcastContent": "none",
+        "publishTime": "2006-07-17T15:22:55Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "ihfJHddAby6yRdYcrvuzi9ODWi0",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCT7njg__VOy3n-SvXemDHvg"
+      },
+      "snippet": {
+        "publishedAt": "2015-03-12T04:37:44Z",
+        "channelId": "UCT7njg__VOy3n-SvXemDHvg",
+        "title": "Core-A Gaming",
+        "description": "Videos about fighting games.",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSpUYiXB1_gJKOFJU_-xBha71wc4XuDMHGeZjg3HA=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSpUYiXB1_gJKOFJU_-xBha71wc4XuDMHGeZjg3HA=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSpUYiXB1_gJKOFJU_-xBha71wc4XuDMHGeZjg3HA=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "Core-A Gaming",
+        "liveBroadcastContent": "upcoming",
+        "publishTime": "2015-03-12T04:37:44Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "Ud0FM9vSXsrPgTt7WPBL6uhMftA",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCvv9tYxOWhqUy9tsdFtVLsQ"
+      },
+      "snippet": {
+        "publishedAt": "2021-10-30T18:53:44Z",
+        "channelId": "UCvv9tYxOWhqUy9tsdFtVLsQ",
+        "title": "Esmail Gaming",
+        "description": "",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/KLnSQ4824gozw-UG-30vQLLRhvHp_FdlytrR7mV8XzF41xSD13hZA7uNjf_K-DB7zZgTXrpXCg=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/KLnSQ4824gozw-UG-30vQLLRhvHp_FdlytrR7mV8XzF41xSD13hZA7uNjf_K-DB7zZgTXrpXCg=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/KLnSQ4824gozw-UG-30vQLLRhvHp_FdlytrR7mV8XzF41xSD13hZA7uNjf_K-DB7zZgTXrpXCg=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "Esmail Gaming",
+        "liveBroadcastContent": "live",
+        "publishTime": "2021-10-30T18:53:44Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "Gri9DoOlSk0OZTggxANzqjR6vIs",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCFqmcAvY-lLQHJcfOHJavGQ"
+      },
+      "snippet": {
+        "publishedAt": "2016-01-01T22:04:10Z",
+        "channelId": "UCFqmcAvY-lLQHJcfOHJavGQ",
+        "title": "kAN Gaming",
+        "description": "Welcome to the kAN Gaming channel! I like playing games and sometimes making videos about them!",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSh50hIcW4ojWV3ql8XsFQ9IVRbjrnzFujEGRWPZw=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSh50hIcW4ojWV3ql8XsFQ9IVRbjrnzFujEGRWPZw=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSh50hIcW4ojWV3ql8XsFQ9IVRbjrnzFujEGRWPZw=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "kAN Gaming",
+        "liveBroadcastContent": "upcoming",
+        "publishTime": "2016-01-01T22:04:10Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "G7i0XU_yla0XMYcAKjuxNBniVdM",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCATWC1JSlhzmYeDbjnS8WwA"
+      },
+      "snippet": {
+        "publishedAt": "2016-11-15T17:40:34Z",
+        "channelId": "UCATWC1JSlhzmYeDbjnS8WwA",
+        "title": "Senpai Gaming",
+        "description": "Live Streaming in a nutshell | Camera/Mic Reviews, Social Media Strats, Gaming/Streaming PC Builds, Sponsorship Help, all the ...",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/Ay_iISsAu4H7cUnelRLu7ZOT5YQP_NGRHkEXH3D-i-jWiRbKpgLhHqP5Iv3f5Q4eaZfwT3-oxw=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/Ay_iISsAu4H7cUnelRLu7ZOT5YQP_NGRHkEXH3D-i-jWiRbKpgLhHqP5Iv3f5Q4eaZfwT3-oxw=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/Ay_iISsAu4H7cUnelRLu7ZOT5YQP_NGRHkEXH3D-i-jWiRbKpgLhHqP5Iv3f5Q4eaZfwT3-oxw=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "Senpai Gaming",
+        "liveBroadcastContent": "none",
+        "publishTime": "2016-11-15T17:40:34Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "5yvI1cFoeA6ddnz3GTFQzhdN5Hw",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UC_DCVMhIdgwQ1uUE76XLXZg"
+      },
+      "snippet": {
+        "publishedAt": "2014-10-21T14:59:26Z",
+        "channelId": "UC_DCVMhIdgwQ1uUE76XLXZg",
+        "title": "DieselDesigns Gaming",
+        "description": "A Wild Array of games from Simulators, Creative Building, Sandbox Games, and MORE! Videos every day, Live Streams Every ...",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSrcXnKj0iu0yWrEzF_7F9MSoGyLrhXzCS2aD4SIA=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSrcXnKj0iu0yWrEzF_7F9MSoGyLrhXzCS2aD4SIA=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLSrcXnKj0iu0yWrEzF_7F9MSoGyLrhXzCS2aD4SIA=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "DieselDesigns Gaming",
+        "liveBroadcastContent": "none",
+        "publishTime": "2014-10-21T14:59:26Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "0Bqam1CvnrNhOFbHXN6TA7CYH60",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCz2_M6-NBgdiLvDOmlH074g"
+      },
+      "snippet": {
+        "publishedAt": "2013-03-18T16:10:13Z",
+        "channelId": "UCz2_M6-NBgdiLvDOmlH074g",
+        "title": "The Gaming Merchant",
+        "description": "Welcome To The Gaming Merchant. Currently I am playing Apex Legends! I am doing Apex Legends guides, tips and tricks, and ...",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLTJpdk3o-GvuI29qUgjbzM7gYH5rhAtb496lhNwqQ=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLTJpdk3o-GvuI29qUgjbzM7gYH5rhAtb496lhNwqQ=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLTJpdk3o-GvuI29qUgjbzM7gYH5rhAtb496lhNwqQ=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "The Gaming Merchant",
+        "liveBroadcastContent": "none",
+        "publishTime": "2013-03-18T16:10:13Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "gAKod91BaKOqjcpam_4ZdN3DMsM",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UC15pq102hQe7FnGq68gKHoQ"
+      },
+      "snippet": {
+        "publishedAt": "2019-09-17T18:35:17Z",
+        "channelId": "UC15pq102hQe7FnGq68gKHoQ",
+        "title": "Ic0n Gaming",
+        "description": "Hey guys! My name is Ic0n and this is my gaming channel. I create playthroughs, game reviews, tutorials and Let's Play series and ...",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/PFrcIPURbZJr-Gqpi02La2CPWjm8Iap0CAkBrMKVKRkdAzRqUqUOItAgIVf0a3-YUPTPpW5J3bI=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/PFrcIPURbZJr-Gqpi02La2CPWjm8Iap0CAkBrMKVKRkdAzRqUqUOItAgIVf0a3-YUPTPpW5J3bI=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/PFrcIPURbZJr-Gqpi02La2CPWjm8Iap0CAkBrMKVKRkdAzRqUqUOItAgIVf0a3-YUPTPpW5J3bI=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "Ic0n Gaming",
+        "liveBroadcastContent": "none",
+        "publishTime": "2019-09-17T18:35:17Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "AymZ1oD35x0b8CzkVqCo0RgsX18",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCmlqW3C9C0_gA0LufzbHfKg"
+      },
+      "snippet": {
+        "publishedAt": "2017-07-19T18:09:38Z",
+        "channelId": "UCmlqW3C9C0_gA0LufzbHfKg",
+        "title": "Legacy Gaming",
+        "description": "Leave a Legacy! Join Codiak and Livid and be part of a fast growing positive gaming community. With in-depth coverage of the ...",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLRQR93GRTH06VuOhwAcR4-fa8Jx4uml2BZXBbVE=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLRQR93GRTH06VuOhwAcR4-fa8Jx4uml2BZXBbVE=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLRQR93GRTH06VuOhwAcR4-fa8Jx4uml2BZXBbVE=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "Legacy Gaming",
+        "liveBroadcastContent": "upcoming",
+        "publishTime": "2017-07-19T18:09:38Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "S6bD5vh1T_L1mdR22SujyYHj0-w",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCDGbmCxt2CEZAsDh1CiWXsQ"
+      },
+      "snippet": {
+        "publishedAt": "2016-11-17T12:29:50Z",
+        "channelId": "UCDGbmCxt2CEZAsDh1CiWXsQ",
+        "title": "False Swipe Gaming",
+        "description": "False Swipe Gaming aims to make quality video content for video games, mainly for Pokemon and Smash at the moment but ...",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLTJMHIHxqRoNPXqDlwuEHTCfwQydXc-LRLFSBn6Ig=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLTJMHIHxqRoNPXqDlwuEHTCfwQydXc-LRLFSBn6Ig=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLTJMHIHxqRoNPXqDlwuEHTCfwQydXc-LRLFSBn6Ig=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "False Swipe Gaming",
+        "liveBroadcastContent": "upcoming",
+        "publishTime": "2016-11-17T12:29:50Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "G1IEstWvYLo8jr65uCsXAlMBljk",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UChIs72whgZI9w6d6FhwGGHA"
+      },
+      "snippet": {
+        "publishedAt": "2009-05-12T02:03:49Z",
+        "channelId": "UChIs72whgZI9w6d6FhwGGHA",
+        "title": "Gamers Nexus",
+        "description": "PC hardware reviews, game benchmarks, component analysis. Please subscribe for updates!",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLS6GBQOV5GZSGqCfZas_glC6Jj1p03J9gnpXKsuxw=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLS6GBQOV5GZSGqCfZas_glC6Jj1p03J9gnpXKsuxw=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLS6GBQOV5GZSGqCfZas_glC6Jj1p03J9gnpXKsuxw=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "Gamers Nexus",
+        "liveBroadcastContent": "upcoming",
+        "publishTime": "2009-05-12T02:03:49Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "qB-1_0tQvlG6fTslz-u9fF0YYKE",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCsmD5774MOQhjYBkXqu3Jdw"
+      },
+      "snippet": {
+        "publishedAt": "2016-03-18T17:47:28Z",
+        "channelId": "UCsmD5774MOQhjYBkXqu3Jdw",
+        "title": "Geek Gaming Scenics",
+        "description": "Hobby channel mostly focused on terrain scenics and sometimes minature painting. Lukes APS has come a long way since the ...",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLRrZHe_M8RkEhjrUMjjZyWhGTXFakN-Mphr9VwrQA=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLRrZHe_M8RkEhjrUMjjZyWhGTXFakN-Mphr9VwrQA=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLRrZHe_M8RkEhjrUMjjZyWhGTXFakN-Mphr9VwrQA=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "Geek Gaming Scenics",
+        "liveBroadcastContent": "upcoming",
+        "publishTime": "2016-03-18T17:47:28Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "fgJhszGnFhkfML-BZTbkTkiK0mE",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCzVnXCLWqY5dtOBn9UZoFTw"
+      },
+      "snippet": {
+        "publishedAt": "2017-08-21T13:01:11Z",
+        "channelId": "UCzVnXCLWqY5dtOBn9UZoFTw",
+        "title": "LEGO Gaming",
+        "description": "Welcome to the LEGO Gaming channel! That's right, a channel dedicated to all things LEGO Games. How awesome is that?",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLR6fGSLjwHo08Xcl9AGW7Z0pqlduemz6wDUWW_ylQ=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLR6fGSLjwHo08Xcl9AGW7Z0pqlduemz6wDUWW_ylQ=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLR6fGSLjwHo08Xcl9AGW7Z0pqlduemz6wDUWW_ylQ=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "LEGO Gaming",
+        "liveBroadcastContent": "none",
+        "publishTime": "2017-08-21T13:01:11Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "38qlx3hksoAaEzMKJzI6PTfPdpE",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCXHGoWpySS0smjanTUDa6Gw"
+      },
+      "snippet": {
+        "publishedAt": "2021-02-22T22:32:08Z",
+        "channelId": "UCXHGoWpySS0smjanTUDa6Gw",
+        "title": "GameToons Gaming",
+        "description": "Welcome to GameToons Gaming! We create mods on your favorite games like Among Us and Friday Night Funkin'!",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLTk6VchZjvf85MNRqYtrC8i86oKFSjuWMeC02fj=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLTk6VchZjvf85MNRqYtrC8i86oKFSjuWMeC02fj=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/ytc/AKedOLTk6VchZjvf85MNRqYtrC8i86oKFSjuWMeC02fj=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "GameToons Gaming",
+        "liveBroadcastContent": "none",
+        "publishTime": "2021-02-22T22:32:08Z"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "SojfK_PR4xrTgCmsgVoo3qY5oi8",
+      "id": {
+        "kind": "youtube#channel",
+        "channelId": "UCX23_3u-d5aMcf-TB8fM9aQ"
+      },
+      "snippet": {
+        "publishedAt": "2022-01-03T07:34:45Z",
+        "channelId": "UCX23_3u-d5aMcf-TB8fM9aQ",
+        "title": "Tallman Gaming",
+        "description": "SUBSCRIBE for your Daily dose of GTA V #Shorts #SUBGOAL 5K THANK Y'ALL SO MUCH FOR EVERYONE WHO SUB!",
+        "thumbnails": {
+          "default": {
+            "url": "https://yt3.ggpht.com/M4vOgM5PQPlc-g-ClEyuErW_4x2ytoNo4YBNS4avRq0LyvFw6HFs5ilLc-ntKEuqMUBKPaA3qA=s88-c-k-c0xffffffff-no-rj-mo"
+          },
+          "medium": {
+            "url": "https://yt3.ggpht.com/M4vOgM5PQPlc-g-ClEyuErW_4x2ytoNo4YBNS4avRq0LyvFw6HFs5ilLc-ntKEuqMUBKPaA3qA=s240-c-k-c0xffffffff-no-rj-mo"
+          },
+          "high": {
+            "url": "https://yt3.ggpht.com/M4vOgM5PQPlc-g-ClEyuErW_4x2ytoNo4YBNS4avRq0LyvFw6HFs5ilLc-ntKEuqMUBKPaA3qA=s800-c-k-c0xffffffff-no-rj-mo"
+          }
+        },
+        "channelTitle": "Tallman Gaming",
+        "liveBroadcastContent": "none",
+        "publishTime": "2022-01-03T07:34:45Z"
+      }
+    }
+  ]
+}
+
 // TODO: handle search that produces no results
 // TODO: Consider a toggle between channels/playlists/videos, or a seies or checkboxes
 
@@ -45,19 +758,19 @@ const Search = () => {
   //   isValidQuery(UrlQuery)
   // );
 
-  // useEffect(() => {
-  //   if (data) {
-  //     console.log(data);
+  useEffect(() => {
+    if (data) {
+      console.log(data);
 
-  //   }
-  //   if (error) {
-  //     console.log(error);
-  //   }
+    }
+    if (error) {
+      console.log(error);
+    }
 
-  //   if (isIdle) {
-  //     console.log('Awaiting conditions for API call');
-  //   }
-  // }, [error, isIdle, data])
+    if (isIdle) {
+      console.log('Awaiting conditions for API call');
+    }
+  }, [error, isIdle, data])
 
   // useEffect(() => {
   //   if (isTwitchLoading) {
@@ -89,9 +802,9 @@ const Search = () => {
           ))}
         </>
       )} */}
-      {data && (
+      {testData && (
         <>
-          {data.items.map((channel) => (
+          {testData.items.map((channel) => (
             <YouTubeChannelResult key={channel.etag} channelData={channel.snippet} />
           ))}
         </>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { ParsedUrlQuery } from "querystring";
 import { useEffect } from 'react';
 import { useYouTubeSearch } from "../hooks/useYoutubeSearch";
+import TwitchChannelResult from '../components/TwitchChannelResult'
 
 // TODO: handle search that produces no results
 // TODO: Consider a toggle between channels/playlists/videos, or a seies or checkboxes
@@ -62,8 +63,8 @@ const Search = () => {
       console.log('Twitch loading');
     }
 
-    if (twitchData) {
-      console.log(twitchData);
+    if (twitchData?.data) {
+      console.log(twitchData.data[0]);
     }
 
     if (twitchError) {
@@ -80,8 +81,16 @@ const Search = () => {
       <div>You searched for {UrlQuery.searchQuery}</div>
       {isTwitchLoading && <div>Twitch loading...</div>}
       {isLoading && <div>YouTube loading...</div>}
+      {twitchData && (
+        <>
+          {twitchData.data.map((channel) => (
+            <TwitchChannelResult key={channel.id} channelData={channel} />
+          ))}
+        </>
+      )}
     </div>
   )
 }
 
 export default Search;
+

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -44,6 +44,10 @@ const Search = () => {
   );
 
   useEffect(() => {
+    if (data) {
+      console.log(data);
+
+    }
     if (error) {
       console.log(error);
     }
@@ -51,7 +55,7 @@ const Search = () => {
     if (isIdle) {
       console.log('Awaiting conditions for API call');
     }
-  }, [error, isIdle])
+  }, [error, isIdle, data])
 
   useEffect(() => {
     if (isTwitchLoading) {

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -4,6 +4,7 @@ import { ParsedUrlQuery } from "querystring";
 import { useEffect } from 'react';
 import { useYouTubeSearch } from "../hooks/useYoutubeSearch";
 import TwitchChannelResult from '../components/TwitchChannelResult'
+import YouTubeChannelResult from "@/components/YouTubeChannelResult";
 
 // TODO: handle search that produces no results
 // TODO: Consider a toggle between channels/playlists/videos, or a seies or checkboxes
@@ -39,52 +40,59 @@ const Search = () => {
     isValidQuery(UrlQuery)
   );
 
-  const { isLoading: isTwitchLoading, isError: isTwitchError, data: twitchData, error: twitchError, isIdle: isTwitchIdle } = useTwitchSearch(
-    sanitiseQuery(UrlQuery),
-    isValidQuery(UrlQuery)
-  );
+  // const { isLoading: isTwitchLoading, isError: isTwitchError, data: twitchData, error: twitchError, isIdle: isTwitchIdle } = useTwitchSearch(
+  //   sanitiseQuery(UrlQuery),
+  //   isValidQuery(UrlQuery)
+  // );
 
-  useEffect(() => {
-    if (data) {
-      console.log(data);
+  // useEffect(() => {
+  //   if (data) {
+  //     console.log(data);
 
-    }
-    if (error) {
-      console.log(error);
-    }
+  //   }
+  //   if (error) {
+  //     console.log(error);
+  //   }
 
-    if (isIdle) {
-      console.log('Awaiting conditions for API call');
-    }
-  }, [error, isIdle, data])
+  //   if (isIdle) {
+  //     console.log('Awaiting conditions for API call');
+  //   }
+  // }, [error, isIdle, data])
 
-  useEffect(() => {
-    if (isTwitchLoading) {
-      console.log('Twitch loading');
-    }
+  // useEffect(() => {
+  //   if (isTwitchLoading) {
+  //     console.log('Twitch loading');
+  //   }
 
-    if (twitchData?.data) {
-      console.log(twitchData.data[0]);
-    }
+  //   if (twitchData?.data) {
+  //     console.log(twitchData.data[0]);
+  //   }
 
-    if (twitchError) {
-      console.log(twitchError);
-    }
+  //   if (twitchError) {
+  //     console.log(twitchError);
+  //   }
 
-    if (isTwitchIdle) {
-      console.log('Awaiting conditions for Twitch API call');
-    }
-  }, [isTwitchLoading, isTwitchIdle, twitchData, twitchError])
+  //   if (isTwitchIdle) {
+  //     console.log('Awaiting conditions for Twitch API call');
+  //   }
+  // }, [isTwitchLoading, isTwitchIdle, twitchData, twitchError])
 
   return (
     <div>
       <div>You searched for {UrlQuery.searchQuery}</div>
-      {isTwitchLoading && <div>Twitch loading...</div>}
+      {/* {isTwitchLoading && <div>Twitch loading...</div>} */}
       {isLoading && <div>YouTube loading...</div>}
-      {twitchData && (
+      {/* {twitchData && (
         <>
           {twitchData.data.map((channel) => (
             <TwitchChannelResult key={channel.id} channelData={channel} />
+          ))}
+        </>
+      )} */}
+      {data && (
+        <>
+          {data.items.map((channel) => (
+            <YouTubeChannelResult key={channel.etag} channelData={channel.snippet} />
           ))}
         </>
       )}

--- a/styles/componentStyles/TwitchSearchResult.module.css
+++ b/styles/componentStyles/TwitchSearchResult.module.css
@@ -1,0 +1,46 @@
+.channel {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 1rem 0;
+  max-width: 500px;
+}
+
+.channelTitle {
+  padding: 0;
+  margin: 0 0 0.5rem 0;
+}
+
+.imgContainer {
+  position: relative;
+}
+
+.live {
+  position: absolute;
+  background-color: red;
+  color: white;
+  font-weight: bold;
+  padding: 0.1rem 0.5rem;
+  border-radius: 3px;
+  top: 0;
+  left: 0;
+  font-size: 0.85rem;
+  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+}
+
+.thumbnail {
+  border-radius: 100%;
+}
+
+.channelText {
+  margin-left: 2rem;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+}
+
+.game {
+  font-size: 0.85rem;
+  margin: 0;
+  color: grey;
+}

--- a/styles/componentStyles/YouTubeSearchResult.module.css
+++ b/styles/componentStyles/YouTubeSearchResult.module.css
@@ -1,0 +1,29 @@
+.channel {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 1rem 0;
+  max-width: 500px;
+}
+
+.channelTitle {
+  padding: 0;
+  margin: 0 0 0.5rem 0;
+}
+
+.thumbnail {
+  border-radius: 100%;
+}
+
+.channelText {
+  margin-left: 2rem;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+}
+
+.description {
+  font-size: 0.85rem;
+  margin: 0;
+  color: grey;
+}

--- a/types/youtubeAPITypes.ts
+++ b/types/youtubeAPITypes.ts
@@ -12,12 +12,12 @@ export interface YouTubeSearchResultSnippet {
       width?: number;
       height?: number;
     };
-    medium?: {
+    medium: {
       url: string,
       width?: number;
       height?: number;
     };
-    high?: {
+    high: {
       url: string,
       width?: number;
       height?: number;

--- a/types/youtubeAPITypes.ts
+++ b/types/youtubeAPITypes.ts
@@ -14,7 +14,8 @@ export interface YouTubeSearchResultSnippet {
     }
   },
   channelTitle: string,
-  liveBroadcastContent: string
+  liveBroadcastContent: string;
+  publishTime?: string;
 }
 
 // Individual search result items

--- a/types/youtubeAPITypes.ts
+++ b/types/youtubeAPITypes.ts
@@ -7,11 +7,21 @@ export interface YouTubeSearchResultSnippet {
   title: string;
   description: string;
   thumbnails: {
-    [key: string]: {
+    default: {
       url: string,
       width?: number;
       height?: number;
-    }
+    };
+    medium?: {
+      url: string,
+      width?: number;
+      height?: number;
+    };
+    high?: {
+      url: string,
+      width?: number;
+      height?: number;
+    };
   },
   channelTitle: string,
   liveBroadcastContent: string;

--- a/types/youtubeAPITypes.ts
+++ b/types/youtubeAPITypes.ts
@@ -1,7 +1,24 @@
 // * Use this file to declare any typings related to the YouTube API
 
+// YouTube Snippet (a summary of the search result item)
+export interface YouTubeSearchResultSnippet {
+  publishedAt: string;
+  channelId: string;
+  title: string;
+  description: string;
+  thumbnails: {
+    [key: string]: {
+      url: string,
+      width?: number;
+      height?: number;
+    }
+  },
+  channelTitle: string,
+  liveBroadcastContent: string
+}
+
 // Individual search result items
-export interface SearchResult {
+export interface YouTubeSearchResult {
   kind: string;
   etag: string;
   id: {
@@ -10,25 +27,11 @@ export interface SearchResult {
     channelId?: string;
     playlistId?: string;
   },
-  snippet: {
-    publishedAt: string;
-    channelId: string;
-    title: string;
-    description: string;
-    thumbnails: {
-      [key: string]: {
-        url: string,
-        width?: number;
-        height?: number;
-      }
-    },
-    channelTitle: string,
-    liveBroadcastContent: string
-  }
+  snippet: YouTubeSearchResultSnippet;
 }
 
 // Result returned by the Search: list YouTube API method
-export interface SearchListResponse {
+export interface YouTubeSearchListResponse {
   kind: string;
   etag: string;
   nextPageToken?: string;
@@ -38,5 +41,5 @@ export interface SearchListResponse {
     totalResults: number;
     resultsPerPage: number;
   }
-  items: SearchResult[];
+  items: YouTubeSearchResult[];
 }


### PR DESCRIPTION
This PR adds two new components:
1. YouTubeSearchResult
2. TwitchSearchResult

These components aim to display a user-friendly channel summary. This component is used to populate the search results list on the search page. Each version is suited to receiving platform-unique data.

Both components are tested. Note this is not a complete component, but instead adds all the non-interactive UI elements.