### PR TITLE
Twitch video filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 # misc
 .DS_Store
 *.pem
+.idea/
 
 # debug
 npm-debug.log*

--- a/__tests__/componentTests/TwitchChannelVideos.test.tsx
+++ b/__tests__/componentTests/TwitchChannelVideos.test.tsx
@@ -72,6 +72,31 @@ jest.mock('../../hooks/useGetTwitchVideos', () => ({
 }));
 
 describe('Twitch videos loading/error/data UI states', () => {
+  it('Hides the videos by default', () => {
+    render(<TwitchChannelVideos userId='1234' />)
+
+    // Check the reveal button is shown
+    const btn = screen.getByRole('button', { name: /reveal videos/i });
+    expect(btn).toBeInTheDocument();
+
+    // Ensure the video overlay is shown
+    const videos = screen.getByTestId('overlay');
+    expect(videos).toBeInTheDocument();
+  });
+
+  it('Shows the videos on click of reveal btn', async () => {
+    render(<TwitchChannelVideos userId='1234' />);
+
+    // First click button
+    const btn = screen.getByRole('button', { name: /reveal videos/i });
+    await userEvent.click(btn);
+
+    // Ensure the video overlay is shown
+    const videos = screen.queryByTestId('overlay');
+    expect(videos).not.toBeInTheDocument();
+  });
+
+
   it('Renders only loading UI while data is loading', () => {
     mockResult.isLoading = true;
     render(<TwitchChannelVideos userId='1234' />)

--- a/__tests__/componentTests/TwitchChannelVideos.test.tsx
+++ b/__tests__/componentTests/TwitchChannelVideos.test.tsx
@@ -167,3 +167,19 @@ describe('Twitch videos loading/error/data UI states', () => {
     expect(selectElement.value).toBe('all');
   });
 });
+
+describe('Video type filter', () => {
+  it('Defaults the video type select element to "Broadcasts"', () => {
+    render(<TwitchChannelVideos userId='1234' />)
+    const selectElement: HTMLSelectElement = screen.getByLabelText(/video type/i)
+    expect(selectElement.value).toBe('archive');
+  });
+
+  it('Correctly handles selecting different video type options', async () => {
+    render(<TwitchChannelVideos userId='1234' />)
+    const selectElement: HTMLSelectElement = screen.getByLabelText(/video type/i);
+    const allOption: HTMLOptionElement = screen.getByTestId(/allOption/i);
+    await userEvent.selectOptions(selectElement, allOption)
+    expect(selectElement.value).toBe('all');
+  });
+});

--- a/__tests__/componentTests/TwitchFilterMenu.test.tsx
+++ b/__tests__/componentTests/TwitchFilterMenu.test.tsx
@@ -28,17 +28,24 @@ const testVideos: HelixVideo[] = [
   }
 ]
 
-
+// Use this before any testing involving the filter controls because they will be initially hidden by default
+const setup = async () => {
+  render(<TwitchFilterMenu filters={filters} setFilters={jest.fn} />)
+  const filtersBtn: HTMLButtonElement = screen.getByRole('button', { name: /filters/i });
+  expect(filtersBtn).toBeInTheDocument();
+  // Reveal the filter controls
+  await userEvent.click(filtersBtn);
+}
 
 describe('Video keyword filter', () => {
-  it('Defaults with empty search box', () => {
-    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+  it('Defaults with empty search box', async () => {
+    await setup();
     const keywordInput: HTMLInputElement = screen.getByLabelText(/keyword/i)
     expect(keywordInput.value).toBe('');
   });
 
   it('Correctly updates UI when user types input', async () => {
-    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    await setup();
     const keywordInput: HTMLInputElement = screen.getByLabelText(/keyword/i)
 
     await userEvent.type(keywordInput, 'test')
@@ -47,14 +54,14 @@ describe('Video keyword filter', () => {
 });
 
 describe('Video date filter', () => {
-  it('Defaults to current date', () => {
-    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+  it('Defaults to current date', async () => {
+    await setup();
     const datePicker: HTMLInputElement = screen.getByLabelText(/date/i);
     expect(datePicker.value).toBe(new Date().toLocaleDateString('en-CA'));
   });
 
-  it('Updates date picker UI on user date input', () => {
-    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+  it('Updates date picker UI on user date input', async () => {
+    await setup();
     const datePicker: HTMLInputElement = screen.getByLabelText(/date/i);
     fireEvent.change(datePicker, { target: { value: "2022-11-11" } });
     expect(datePicker.value).toBe("2022-11-11");
@@ -62,8 +69,8 @@ describe('Video date filter', () => {
 });
 
 describe('Video duration filter', () => {
-  it('Gives the user preset duration options', () => {
-    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+  it('Gives the user preset duration options', async () => {
+    await setup();
     const anyDuration = screen.getByLabelText(/any duration/i);
     const durationOne = screen.getByLabelText(/under 5 minutes/i);
     const durationTwo = screen.getByLabelText(/5 - 60 minutes/i);
@@ -76,14 +83,14 @@ describe('Video duration filter', () => {
     expect(durationFour).toBeInTheDocument();
   });
 
-  it('initialises min and max durations to "Any"', () => {
-    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+  it('initialises min and max durations to "Any"', async () => {
+    await setup();
     const anyDuration: HTMLInputElement = screen.getByLabelText(/any duration/i);
     expect(anyDuration.checked).toBe(true);
   })
 
   it('Allows the user to select a single duration filter at a time', async () => {
-    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    await setup();
     const anyDuration: HTMLInputElement = screen.getByLabelText(/any duration/i);
     const durationOne: HTMLInputElement = screen.getByLabelText(/under 5 minutes/i);
     const durationTwo: HTMLInputElement = screen.getByLabelText(/5 - 60 minutes/i);
@@ -100,13 +107,13 @@ describe('Video duration filter', () => {
 
 describe('Video filter UI', () => {
   it('Defaults with filters hidden', () => {
-    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    render(<TwitchFilterMenu filters={filters} setFilters={jest.fn} />)
     const filterControls = screen.queryByLabelText(/duration/i);
     expect(filterControls).not.toBeInTheDocument()
   });
 
   it('Opens filter controls on click of filters button', async () => {
-    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    render(<TwitchFilterMenu filters={filters} setFilters={jest.fn} />)
     const filtersBtn: HTMLButtonElement = screen.getByRole('button', { name: /filters/i });
     expect(filtersBtn).toBeInTheDocument();
 
@@ -117,7 +124,7 @@ describe('Video filter UI', () => {
   });
 
   it('Closes filter controls on second click of filters button', async () => {
-    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    render(<TwitchFilterMenu filters={filters} setFilters={jest.fn} />)
     const filtersBtn: HTMLButtonElement = screen.getByRole('button', { name: /filters/i });
     expect(filtersBtn).toBeInTheDocument();
 

--- a/__tests__/componentTests/TwitchFilterMenu.test.tsx
+++ b/__tests__/componentTests/TwitchFilterMenu.test.tsx
@@ -136,3 +136,20 @@ describe('Video filter UI', () => {
     expect(filterControls).not.toBeInTheDocument();
   });
 });
+
+describe('Applying filters', () => {
+  it('Sets filters when "Apply filters" is clicked', async () => {
+    const mockSetFilters = jest.fn();
+    render(<TwitchFilterMenu filters={filters} setFilters={mockSetFilters} />)
+    const filtersBtn: HTMLButtonElement = screen.getByRole('button', { name: /filters/i });
+    expect(filtersBtn).toBeInTheDocument();
+
+    // Reveal the filter controls
+    await userEvent.click(filtersBtn);
+
+    const applyBtn = screen.getByRole('button', { name: /apply filters/i });
+    await userEvent.click(applyBtn);
+
+    expect(mockSetFilters).toHaveBeenCalled()
+  });
+});

--- a/__tests__/componentTests/TwitchFilterMenu.test.tsx
+++ b/__tests__/componentTests/TwitchFilterMenu.test.tsx
@@ -70,35 +70,37 @@ describe('Video date filter', () => {
 describe('Video duration filter', () => {
   it('Gives the user preset duration options', () => {
     render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    const anyDuration = screen.getByLabelText(/any duration/i);
     const durationOne = screen.getByLabelText(/under 5 minutes/i);
     const durationTwo = screen.getByLabelText(/5 - 60 minutes/i);
     const durationThree = screen.getByLabelText(/1 - 4 hours/i);
-    const durationFour = screen.getByLabelText(/over 6 hours/i);
+    const durationFour = screen.getByLabelText(/over 4 hours/i);
+    expect(anyDuration).toBeInTheDocument();
     expect(durationOne).toBeInTheDocument();
     expect(durationTwo).toBeInTheDocument();
     expect(durationThree).toBeInTheDocument();
     expect(durationFour).toBeInTheDocument();
   });
 
+  it('initialises min and max durations to "Any"', () => {
+    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    const anyDuration: HTMLInputElement = screen.getByLabelText(/any duration/i);
+    expect(anyDuration.checked).toBe(true);
+  })
+
   it('Allows the user to select a single duration filter at a time', async () => {
     render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    const anyDuration: HTMLInputElement = screen.getByLabelText(/any duration/i);
     const durationOne: HTMLInputElement = screen.getByLabelText(/under 5 minutes/i);
     const durationTwo: HTMLInputElement = screen.getByLabelText(/5 - 60 minutes/i);
     const durationThree: HTMLInputElement = screen.getByLabelText(/1 - 4 hours/i);
-    const durationFour: HTMLInputElement = screen.getByLabelText(/over 6 hours/i);
+    const durationFour: HTMLInputElement = screen.getByLabelText(/over 4 hours/i);
     await userEvent.click(durationTwo)
+    expect(anyDuration.checked).toBe(false);
     expect(durationOne.checked).toBe(false);
     expect(durationTwo.checked).toBe(true);
     expect(durationThree.checked).toBe(false);
     expect(durationFour.checked).toBe(false);
   });
-
-  it('initialises min and max durations to "Any"', () => {
-    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
-    const maxDuration: HTMLInputElement = screen.getByLabelText(/max/i);
-    const minDuration: HTMLInputElement = screen.getByLabelText(/min/i);
-    expect(maxDuration.value).toBe(0);
-    expect(maxDuration.value).toBe(180000);
-  })
 });
 

--- a/__tests__/componentTests/TwitchFilterMenu.test.tsx
+++ b/__tests__/componentTests/TwitchFilterMenu.test.tsx
@@ -9,7 +9,6 @@ const filters: VideoFilters = {
   minDurationFilter: null,
   maxDurationFilter: null,
   keywordFilter: null,
-  videoType: 'archive'
 }
 
 const testVideos: HelixVideo[] = [
@@ -29,21 +28,7 @@ const testVideos: HelixVideo[] = [
   }
 ]
 
-describe('Video type filter', () => {
-  it('Defaults the video type select element to "Broadcasts"', () => {
-    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
-    const selectElement: HTMLSelectElement = screen.getByLabelText(/video type/i)
-    expect(selectElement.value).toBe('archive');
-  });
 
-  it('Correctly handles selecting different video type options', async () => {
-    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
-    const selectElement: HTMLSelectElement = screen.getByLabelText(/video type/i);
-    const allOption: HTMLOptionElement = screen.getByTestId(/allOption/i);
-    await userEvent.selectOptions(selectElement, allOption)
-    expect(selectElement.value).toBe('all');
-  });
-});
 
 describe('Video keyword filter', () => {
   it('Defaults with empty search box', () => {

--- a/__tests__/componentTests/TwitchFilterMenu.test.tsx
+++ b/__tests__/componentTests/TwitchFilterMenu.test.tsx
@@ -6,7 +6,8 @@ import {HelixVideo} from "@twurple/api";
 
 const filters: VideoFilters = {
   dateFilter: null,
-  durationFilter: null,
+  minDurationFilter: null,
+  maxDurationFilter: null,
   keywordFilter: null,
   videoType: 'archive'
 }
@@ -91,5 +92,13 @@ describe('Video duration filter', () => {
     expect(durationThree.checked).toBe(false);
     expect(durationFour.checked).toBe(false);
   });
+
+  it('initialises min and max durations to "Any"', () => {
+    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    const maxDuration: HTMLInputElement = screen.getByLabelText(/max/i);
+    const minDuration: HTMLInputElement = screen.getByLabelText(/min/i);
+    expect(maxDuration.value).toBe(0);
+    expect(maxDuration.value).toBe(180000);
+  })
 });
 

--- a/__tests__/componentTests/TwitchFilterMenu.test.tsx
+++ b/__tests__/componentTests/TwitchFilterMenu.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TwitchFilterMenu from "@/components/TwitchFilterMenu";
 import {VideoFilters} from "@/components/TwitchChannelVideos";
@@ -62,8 +62,18 @@ describe('Video keyword filter', () => {
 });
 
 describe('Video date filter', () => {
-  it.todo('Defaults to current date');
-  it.todo('Updates date picker UI on user date input');
+  it('Defaults to current date', () => {
+    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    const datePicker: HTMLInputElement = screen.getByLabelText(/date/i);
+    expect(datePicker.value).toBe(new Date().toLocaleDateString('en-CA'));
+  });
+
+  it('Updates date picker UI on user date input', () => {
+    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    const datePicker: HTMLInputElement = screen.getByLabelText(/date/i);
+    fireEvent.change(datePicker, { target: { value: "2022-11-11" } });
+    expect(datePicker.value).toBe("2022-11-11");
+  });
 });
 
 describe('Video duration filter', () => {

--- a/__tests__/componentTests/TwitchFilterMenu.test.tsx
+++ b/__tests__/componentTests/TwitchFilterMenu.test.tsx
@@ -46,11 +46,10 @@ describe('Video type filter', () => {
 });
 
 describe('Video keyword filter', () => {
-  it('Defaults with empty search box with placeholder', () => {
+  it('Defaults with empty search box', () => {
     render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
     const keywordInput: HTMLInputElement = screen.getByLabelText(/keyword/i)
     expect(keywordInput.value).toBe('');
-    expect(keywordInput.placeholder).toBe('Filter by keyword');
   });
 
   it('Correctly updates UI when user types input', async () => {
@@ -63,7 +62,7 @@ describe('Video keyword filter', () => {
 });
 
 describe('Video date filter', () => {
-  it.todo('Defaults to "Any" initial value"');
+  it.todo('Defaults to current date');
   it.todo('Updates date picker UI on user date input');
 });
 

--- a/__tests__/componentTests/TwitchFilterMenu.test.tsx
+++ b/__tests__/componentTests/TwitchFilterMenu.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TwitchFilterMenu from "@/components/TwitchFilterMenu";
+import {VideoFilters} from "@/components/TwitchChannelVideos";
+import {HelixVideo} from "@twurple/api";
+
+const filters: VideoFilters = {
+  dateFilter: null,
+  durationFilter: null,
+  keywordFilter: null,
+  videoType: 'archive'
+}
+
+const testVideos: HelixVideo[] = [
+  {
+    durationInSeconds: 18000,   // 05:00:00
+    creationDate: new Date(2022, 5, 12),
+    title: "video one",
+    // @ts-expect-error exact getUser implementation not needed in these tests
+    getUser: jest.fn,
+  },
+  {
+    durationInSeconds: 8274,    // 02:15:54
+    creationDate: new Date(2022, 4, 12),
+    title: "video two",
+    // @ts-expect-error exact getUser implementation not needed in these tests
+    getUser: jest.fn,
+  }
+]
+
+describe('Twitch videos loading/error/data UI states', () => {
+  it('Defaults the video type select element to "Broadcasts"', () => {
+    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    const selectElement: HTMLSelectElement = screen.getByLabelText(/video type/i)
+    expect(selectElement.value).toBe('archive');
+  });
+
+  it('Correctly handles selecting different video type options', async () => {
+    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    const selectElement: HTMLSelectElement = screen.getByLabelText(/video type/i);
+    const allOption: HTMLOptionElement = screen.getByTestId(/allOption/i);
+    await userEvent.selectOptions(selectElement, allOption)
+    expect(selectElement.value).toBe('all');
+  });
+});

--- a/__tests__/componentTests/TwitchFilterMenu.test.tsx
+++ b/__tests__/componentTests/TwitchFilterMenu.test.tsx
@@ -28,7 +28,7 @@ const testVideos: HelixVideo[] = [
   }
 ]
 
-describe('Twitch videos loading/error/data UI states', () => {
+describe('Video type filter', () => {
   it('Defaults the video type select element to "Broadcasts"', () => {
     render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
     const selectElement: HTMLSelectElement = screen.getByLabelText(/video type/i)
@@ -43,3 +43,53 @@ describe('Twitch videos loading/error/data UI states', () => {
     expect(selectElement.value).toBe('all');
   });
 });
+
+describe('Video keyword filter', () => {
+  it('Defaults with empty search box with placeholder', () => {
+    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    const keywordInput: HTMLInputElement = screen.getByLabelText(/keyword/i)
+    expect(keywordInput.value).toBe('');
+    expect(keywordInput.placeholder).toBe('Filter by keyword');
+  });
+
+  it('Correctly updates UI when user types input', async () => {
+    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    const keywordInput: HTMLInputElement = screen.getByLabelText(/keyword/i)
+
+    await userEvent.type(keywordInput, 'test')
+    expect(keywordInput.value).toBe('test');
+  });
+});
+
+describe('Video date filter', () => {
+  it.todo('Defaults to "Any" initial value"');
+  it.todo('Updates date picker UI on user date input');
+});
+
+describe('Video duration filter', () => {
+  it('Gives the user preset duration options', () => {
+    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    const durationOne = screen.getByLabelText(/under 5 minutes/i);
+    const durationTwo = screen.getByLabelText(/5 - 60 minutes/i);
+    const durationThree = screen.getByLabelText(/1 - 4 hours/i);
+    const durationFour = screen.getByLabelText(/over 6 hours/i);
+    expect(durationOne).toBeInTheDocument();
+    expect(durationTwo).toBeInTheDocument();
+    expect(durationThree).toBeInTheDocument();
+    expect(durationFour).toBeInTheDocument();
+  });
+
+  it('Allows the user to select a single duration filter at a time', async () => {
+    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    const durationOne: HTMLInputElement = screen.getByLabelText(/under 5 minutes/i);
+    const durationTwo: HTMLInputElement = screen.getByLabelText(/5 - 60 minutes/i);
+    const durationThree: HTMLInputElement = screen.getByLabelText(/1 - 4 hours/i);
+    const durationFour: HTMLInputElement = screen.getByLabelText(/over 6 hours/i);
+    await userEvent.click(durationTwo)
+    expect(durationOne.checked).toBe(false);
+    expect(durationTwo.checked).toBe(true);
+    expect(durationThree.checked).toBe(false);
+    expect(durationFour.checked).toBe(false);
+  });
+});
+

--- a/__tests__/componentTests/TwitchFilterMenu.test.tsx
+++ b/__tests__/componentTests/TwitchFilterMenu.test.tsx
@@ -113,3 +113,34 @@ describe('Video duration filter', () => {
   });
 });
 
+describe('Video filter UI', () => {
+  it('Defaults with filters hidden', () => {
+    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    const filterControls = screen.queryByLabelText(/duration/i);
+    expect(filterControls).not.toBeInTheDocument()
+  });
+
+  it('Opens filter controls on click of filters button', async () => {
+    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    const filtersBtn: HTMLButtonElement = screen.getByRole('button', { name: /filters/i });
+    expect(filtersBtn).toBeInTheDocument();
+
+    // Reveal the filter controls
+    await userEvent.click(filtersBtn);
+    const filterControls = screen.getByLabelText(/duration/i);
+    expect(filterControls).toBeInTheDocument();
+  });
+
+  it('Closes filter controls on second click of filters button', async () => {
+    render(<TwitchFilterMenu filters={filters} filteredVideos={testVideos} setFilteredVideos={jest.fn} setFilters={jest.fn} />)
+    const filtersBtn: HTMLButtonElement = screen.getByRole('button', { name: /filters/i });
+    expect(filtersBtn).toBeInTheDocument();
+
+    // Reveal then hide the filter controls
+    await userEvent.click(filtersBtn);
+    await userEvent.click(filtersBtn);
+
+    const filterControls = screen.queryByLabelText(/duration/i);
+    expect(filterControls).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/pageTests/twitchChannelPage.test.tsx
+++ b/__tests__/pageTests/twitchChannelPage.test.tsx
@@ -94,29 +94,6 @@ describe('Channel page layout and elements', () => {
     const images = screen.getAllByRole('img');
     expect(images).toHaveLength(2);
   });
-
-  it('Hides the channel videos section by default', () => {
-    render(<TwitchChannelPage channelId='1234' />)
-
-    // Check the reveal button is shown
-    const btn = screen.getByRole('button', { name: /toggle videos/i });
-    expect(btn).toBeInTheDocument();
-
-    const videos = screen.queryByRole('heading', { name: /videos/i });
-    expect(videos).not.toBeInTheDocument();
-  });
-
-  it('Shows the channel videos section on click of reveal btn', async () => {
-    render(<TwitchChannelPage channelId='1234' />);
-
-    // First click button
-    const btn = screen.getByRole('button', { name: /toggle videos/i });
-    await userEvent.click(btn);
-
-    // Then check for presence of videos section
-    const videos = screen.getByRole('heading', { name: /videos/i });
-    expect(videos).toBeInTheDocument();
-  });
 });
 
 describe('Channel page UI states', () => {

--- a/__tests__/twitchVideoFilters.test.ts
+++ b/__tests__/twitchVideoFilters.test.ts
@@ -39,7 +39,7 @@ const testVideos: HelixVideo[] = [
   },
   {
     durationInSeconds: 1234,    // 00:20:34
-    creationDate: new Date(2022, 5, 12),
+    creationDate: new Date(2022, 5, 12, 5),
     title: "video six",
     // @ts-expect-error exact getUser implementation not needed in these tests
     getUser: jest.fn,
@@ -130,23 +130,48 @@ describe('Filter videos by title keyword', () => {
 })
 
 describe('Filter videos by date', () => {
-  it('returns all videos newer than the provided date', () => {
-    expect(filterByDate(testVideos, new Date(2021, 1, 1))).toStrictEqual(testVideos);
+  it('returns all videos older than the provided date', () => {
+    // Should NOT return the 12/05/2022 05:00:00 video!
+    expect(filterByDate(testVideos, new Date(2022, 5, 12))).toStrictEqual([
+      {
+        durationInSeconds: 18000,   // 05:00:00
+        creationDate: new Date(2022, 5, 12),
+        title: "video one",
+        getUser: jest.fn,
+      },
+      {
+        durationInSeconds: 8274,    // 02:15:54
+        creationDate: new Date(2022, 4, 12),
+        title: "video two",
+        getUser: jest.fn,
+      },
+      {
+        durationInSeconds: 10,   // 00:00:10
+        creationDate: new Date(2022, 3, 12),
+        title: "video three",
+        getUser: jest.fn,
+      },
+      {
+        durationInSeconds: 23452,
+        creationDate: new Date(2022, 5, 11),
+        title: "video five",
+        getUser: jest.fn,
+      },
+    ]);
   });
 
-  it('returns videos created on the date provided', () => {
-    //  Aim to filter out all those videos less than 4 hours duration
-    expect(filterByDate(testVideos, new Date(2022, 5, 13))).toStrictEqual([
+  it('includes videos on the specified date (if released at 00:00:00)', () => {
+    expect(filterByDate(testVideos, new Date(2022, 3, 12))).toStrictEqual([
       {
-        durationInSeconds: 45006,    // 12:30:06
-        creationDate: new Date(2022, 5, 13),
-        title: "video four",
+        durationInSeconds: 10,   // 00:00:10
+        creationDate: new Date(2022, 3, 12),
+        title: "video three",
         getUser: jest.fn,
       },
     ]);
   });
 
   it('returns empty list when no videos match the criteria', () => {
-    expect(filterByDate(testVideos, new Date(2022, 7, 3))).toStrictEqual([]);
+    expect(filterByDate(testVideos, new Date(2021, 7, 3))).toStrictEqual([]);
   });
 })

--- a/__tests__/twitchVideoFilters.test.ts
+++ b/__tests__/twitchVideoFilters.test.ts
@@ -44,6 +44,13 @@ const testVideos: HelixVideo[] = [
     // @ts-expect-error exact getUser implementation not needed in these tests
     getUser: jest.fn,
   },
+  {
+    durationInSeconds: 1000,    // 00:20:34
+    creationDate: new Date(),
+    title: "video seven",
+    // @ts-expect-error exact getUser implementation not needed in these tests
+    getUser: jest.fn,
+  },
 ]
 
 describe('Filter videos by duration', () => {
@@ -186,5 +193,9 @@ describe('Filter videos by date', () => {
 
   it('returns empty list when no videos match the criteria', () => {
     expect(filterByDate(testVideos, new Date(2021, 7, 3))).toStrictEqual([]);
+  });
+
+  it('returns all videos when the date filter is set to current date/time', () => {
+    expect(filterByDate(testVideos, new Date())).toStrictEqual(testVideos);
   });
 })

--- a/__tests__/twitchVideoFilters.test.ts
+++ b/__tests__/twitchVideoFilters.test.ts
@@ -1,4 +1,4 @@
-import {filterByDuration} from "../helpers/twitchVideoFilters";
+import {filterByDuration, filterByKeyword} from "../helpers/twitchVideoFilters";
 import {HelixVideo} from "@twurple/api";
 
 const testVideos: HelixVideo[] = [
@@ -16,25 +16,25 @@ const testVideos: HelixVideo[] = [
   },
   {
     durationInSeconds: 10,   // 00:00:10
-    title: "video one",
+    title: "video three",
     // @ts-expect-error exact getUser implementation not needed in these tests
     getUser: jest.fn,
   },
   {
     durationInSeconds: 45006,    // 12:30:06
-    title: "video two",
+    title: "video four",
     // @ts-expect-error exact getUser implementation not needed in these tests
     getUser: jest.fn,
   },
   {
     durationInSeconds: 23452,   // 06:30:52
-    title: "video one",
+    title: "video five",
     // @ts-expect-error exact getUser implementation not needed in these tests
     getUser: jest.fn,
   },
   {
     durationInSeconds: 1234,    // 00:20:34
-    title: "video two",
+    title: "video six",
     // @ts-expect-error exact getUser implementation not needed in these tests
     getUser: jest.fn,
   },
@@ -78,5 +78,41 @@ describe('Filter videos by duration', () => {
 
   it('returns an empty array if no videos exist above the minimum specified duration', () => {
     expect(filterByDuration(testVideos, 50000)).toStrictEqual([]);
+  });
+})
+
+describe('Filter videos by title keyword', () => {
+  it('returns all videos for a single common letter filter', () => {
+    expect(filterByKeyword(testVideos, 'v')).toStrictEqual(testVideos);
+  });
+
+  it('returns all videos when the keyword is any amount of whitespace', () => {
+    expect(filterByKeyword(testVideos, '   ')).toStrictEqual(testVideos);
+  });
+
+  it('returns the appropriate videos given a single keyword search', () => {
+    //  Aim to filter out all those videos less than 4 hours duration
+    expect(filterByKeyword(testVideos, 'one')).toStrictEqual([
+      {
+        durationInSeconds: 18000,   // 05:00:00
+        title: "video one",
+        getUser: jest.fn,
+      },
+    ]);
+  });
+
+  it('returns the appropriate videos given a multiple keyword search', () => {
+    //  Aim to filter out all those videos less than 4 hours duration
+    expect(filterByKeyword(testVideos, 'video two')).toStrictEqual([
+      {
+        durationInSeconds: 8274,    // 12:30:06
+        title: "video two",
+        getUser: jest.fn,
+      },
+    ]);
+  });
+
+  it('returns an empty array if no videos match the search keyword', () => {
+    expect(filterByKeyword(testVideos, 'ten')).toStrictEqual([]);
   });
 })

--- a/__tests__/twitchVideoFilters.test.ts
+++ b/__tests__/twitchVideoFilters.test.ts
@@ -1,39 +1,45 @@
-import {filterByDuration, filterByKeyword} from "../helpers/twitchVideoFilters";
+import {filterByDuration, filterByKeyword, filterByDate} from "../helpers/twitchVideoFilters";
 import {HelixVideo} from "@twurple/api";
 
 const testVideos: HelixVideo[] = [
   {
     durationInSeconds: 18000,   // 05:00:00
+    creationDate: new Date(2022, 5, 12),
     title: "video one",
     // @ts-expect-error exact getUser implementation not needed in these tests
     getUser: jest.fn,
   },
   {
     durationInSeconds: 8274,    // 02:15:54
+    creationDate: new Date(2022, 4, 12),
     title: "video two",
     // @ts-expect-error exact getUser implementation not needed in these tests
     getUser: jest.fn,
   },
   {
     durationInSeconds: 10,   // 00:00:10
+    creationDate: new Date(2022, 3, 12),
     title: "video three",
     // @ts-expect-error exact getUser implementation not needed in these tests
     getUser: jest.fn,
   },
   {
     durationInSeconds: 45006,    // 12:30:06
+    creationDate: new Date(2022, 5, 13),
     title: "video four",
     // @ts-expect-error exact getUser implementation not needed in these tests
     getUser: jest.fn,
   },
   {
     durationInSeconds: 23452,   // 06:30:52
+    creationDate: new Date(2022, 5, 11),
     title: "video five",
     // @ts-expect-error exact getUser implementation not needed in these tests
     getUser: jest.fn,
   },
   {
     durationInSeconds: 1234,    // 00:20:34
+    creationDate: new Date(2022, 5, 12),
     title: "video six",
     // @ts-expect-error exact getUser implementation not needed in these tests
     getUser: jest.fn,
@@ -50,17 +56,20 @@ describe('Filter videos by duration', () => {
     expect(filterByDuration(testVideos, 14400)).toStrictEqual([
       {
         durationInSeconds: 18000,   // 05:00:00
+        creationDate: new Date(2022, 5, 12),
         title: "video one",
         getUser: jest.fn,
       },
       {
         durationInSeconds: 45006,    // 12:30:06
-        title: "video two",
+        creationDate: new Date(2022, 5, 13),
+        title: "video four",
         getUser: jest.fn,
       },
       {
         durationInSeconds: 23452,   // 06:30:52
-        title: "video one",
+        creationDate: new Date(2022, 5, 11),
+        title: "video five",
         getUser: jest.fn,
       },
     ]);
@@ -70,7 +79,8 @@ describe('Filter videos by duration', () => {
     expect(filterByDuration(testVideos, 23452)).toStrictEqual([
       {
         durationInSeconds: 45006,    // 12:30:06
-        title: "video two",
+        creationDate: new Date(2022, 5, 13),
+        title: "video four",
         getUser: jest.fn,
       },
     ]);
@@ -95,6 +105,7 @@ describe('Filter videos by title keyword', () => {
     expect(filterByKeyword(testVideos, 'one')).toStrictEqual([
       {
         durationInSeconds: 18000,   // 05:00:00
+        creationDate: new Date(2022, 5, 12),
         title: "video one",
         getUser: jest.fn,
       },
@@ -105,7 +116,8 @@ describe('Filter videos by title keyword', () => {
     //  Aim to filter out all those videos less than 4 hours duration
     expect(filterByKeyword(testVideos, 'video two')).toStrictEqual([
       {
-        durationInSeconds: 8274,    // 12:30:06
+        durationInSeconds: 8274,    // 02:15:54
+        creationDate: new Date(2022, 4, 12),
         title: "video two",
         getUser: jest.fn,
       },
@@ -114,5 +126,27 @@ describe('Filter videos by title keyword', () => {
 
   it('returns an empty array if no videos match the search keyword', () => {
     expect(filterByKeyword(testVideos, 'ten')).toStrictEqual([]);
+  });
+})
+
+describe('Filter videos by date', () => {
+  it('returns all videos newer than the provided date', () => {
+    expect(filterByDate(testVideos, new Date(2021, 1, 1))).toStrictEqual(testVideos);
+  });
+
+  it('returns videos created on the date provided', () => {
+    //  Aim to filter out all those videos less than 4 hours duration
+    expect(filterByDate(testVideos, new Date(2022, 5, 13))).toStrictEqual([
+      {
+        durationInSeconds: 45006,    // 12:30:06
+        creationDate: new Date(2022, 5, 13),
+        title: "video four",
+        getUser: jest.fn,
+      },
+    ]);
+  });
+
+  it('returns empty list when no videos match the criteria', () => {
+    expect(filterByDate(testVideos, new Date(2022, 7, 3))).toStrictEqual([]);
   });
 })

--- a/__tests__/twitchVideoFilters.test.ts
+++ b/__tests__/twitchVideoFilters.test.ts
@@ -40,7 +40,7 @@ const testVideos: HelixVideo[] = [
   {
     durationInSeconds: 1234,    // 00:20:34
     creationDate: new Date(2022, 5, 12, 5),
-    title: "video six",
+    title: "Video six",
     // @ts-expect-error exact getUser implementation not needed in these tests
     getUser: jest.fn,
   },
@@ -112,7 +112,7 @@ describe('Filter videos by duration', () => {
 })
 
 describe('Filter videos by title keyword', () => {
-  it('returns all videos for a single common letter filter', () => {
+  it('returns all videos for a single common letter filter (case insensitive)', () => {
     expect(filterByKeyword(testVideos, 'v')).toStrictEqual(testVideos);
   });
 

--- a/__tests__/twitchVideoFilters.test.ts
+++ b/__tests__/twitchVideoFilters.test.ts
@@ -1,0 +1,82 @@
+import {filterByDuration} from "../helpers/twitchVideoFilters";
+import {HelixVideo} from "@twurple/api";
+
+const testVideos: HelixVideo[] = [
+  {
+    durationInSeconds: 18000,   // 05:00:00
+    title: "video one",
+    // @ts-expect-error exact getUser implementation not needed in these tests
+    getUser: jest.fn,
+  },
+  {
+    durationInSeconds: 8274,    // 02:15:54
+    title: "video two",
+    // @ts-expect-error exact getUser implementation not needed in these tests
+    getUser: jest.fn,
+  },
+  {
+    durationInSeconds: 10,   // 00:00:10
+    title: "video one",
+    // @ts-expect-error exact getUser implementation not needed in these tests
+    getUser: jest.fn,
+  },
+  {
+    durationInSeconds: 45006,    // 12:30:06
+    title: "video two",
+    // @ts-expect-error exact getUser implementation not needed in these tests
+    getUser: jest.fn,
+  },
+  {
+    durationInSeconds: 23452,   // 06:30:52
+    title: "video one",
+    // @ts-expect-error exact getUser implementation not needed in these tests
+    getUser: jest.fn,
+  },
+  {
+    durationInSeconds: 1234,    // 00:20:34
+    title: "video two",
+    // @ts-expect-error exact getUser implementation not needed in these tests
+    getUser: jest.fn,
+  },
+]
+
+describe('Filter videos by duration', () => {
+  it('returns all videos for zero second duration input', () => {
+    expect(filterByDuration(testVideos, 0)).toStrictEqual(testVideos);
+  });
+
+  it('returns all videos above specified minimum duration', () => {
+  //  Aim to filter out all those videos less than 4 hours duration
+    expect(filterByDuration(testVideos, 14400)).toStrictEqual([
+      {
+        durationInSeconds: 18000,   // 05:00:00
+        title: "video one",
+        getUser: jest.fn,
+      },
+      {
+        durationInSeconds: 45006,    // 12:30:06
+        title: "video two",
+        getUser: jest.fn,
+      },
+      {
+        durationInSeconds: 23452,   // 06:30:52
+        title: "video one",
+        getUser: jest.fn,
+      },
+    ]);
+  });
+
+  it('does not return video with duration equal to the minimum specified', () => {
+    expect(filterByDuration(testVideos, 23452)).toStrictEqual([
+      {
+        durationInSeconds: 45006,    // 12:30:06
+        title: "video two",
+        getUser: jest.fn,
+      },
+    ]);
+  });
+
+  it('returns an empty array if no videos exist above the minimum specified duration', () => {
+    expect(filterByDuration(testVideos, 50000)).toStrictEqual([]);
+  });
+})

--- a/__tests__/twitchVideoFilters.test.ts
+++ b/__tests__/twitchVideoFilters.test.ts
@@ -47,12 +47,12 @@ const testVideos: HelixVideo[] = [
 ]
 
 describe('Filter videos by duration', () => {
-  it('returns all videos for zero second duration input', () => {
+  it('returns all videos for a zero second minimum', () => {
     expect(filterByDuration(testVideos, 0)).toStrictEqual(testVideos);
   });
 
   it('returns all videos above specified minimum duration', () => {
-  //  Aim to filter out all those videos less than 4 hours duration
+    //  Aim to filter out all those videos less than 4 hours duration
     expect(filterByDuration(testVideos, 14400)).toStrictEqual([
       {
         durationInSeconds: 18000,   // 05:00:00
@@ -88,6 +88,19 @@ describe('Filter videos by duration', () => {
 
   it('returns an empty array if no videos exist above the minimum specified duration', () => {
     expect(filterByDuration(testVideos, 50000)).toStrictEqual([]);
+  });
+
+  it('returns an empty array if no videos exist below the maximum specified duration', () => {
+    expect(filterByDuration(testVideos, 0, 0)).toStrictEqual([]);
+  });
+
+  it('returns correct videos in duration interval min-max', () => {
+    expect(filterByDuration(testVideos, 10000, 20000)).toStrictEqual([  {
+      durationInSeconds: 18000,   // 05:00:00
+      creationDate: new Date(2022, 5, 12),
+      title: "video one",
+      getUser: jest.fn,
+    }]);
   });
 })
 

--- a/__tests__/videoDurationConversion.ts
+++ b/__tests__/videoDurationConversion.ts
@@ -24,4 +24,8 @@ describe('Twitch video duration conversion', () => {
   it('Handles single digit seconds correctly', () => {
     expect(convertTwitchVideoDuration('11h10m0s')).toBe('11:10:00')
   });
+
+  it('Handles single digit seconds correctly (leading zeros)', () => {
+    expect(convertTwitchVideoDuration('11m1s')).toBe('11:01')
+  });
 });

--- a/components/TwitchChannelVideos.tsx
+++ b/components/TwitchChannelVideos.tsx
@@ -39,7 +39,6 @@ const TwitchChannelVideos = ({ userId }: TwitchChannelVideosProps) => {
   useEffect(() => {
     let tempVideos: HelixVideo[] = [];
     if (data) {
-      console.log(data)
       // Attempting filter without data will throw an error
       tempVideos = data;
       if (filters) {

--- a/components/TwitchChannelVideos.tsx
+++ b/components/TwitchChannelVideos.tsx
@@ -16,7 +16,7 @@ export interface VideoFilters {
   minDurationFilter: number | null;
   maxDurationFilter: number | null;
   keywordFilter: string | null;
-  videoType: HelixVideoType | undefined | 'all';
+
 }
 
 // Make API call here to fetch videos using channel/user ID
@@ -28,13 +28,20 @@ const TwitchChannelVideos = ({ userId }: TwitchChannelVideosProps) => {
     minDurationFilter: null,
     maxDurationFilter: null,
     keywordFilter: null,
-    videoType: 'archive'
   });
 
-  const [hideVideos, setHideVideos] = useState(true);
+  const handleOptionSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    // This typecasting is required, as you cannot simply assign the 'string' value type to the videoType state
+    setFilters((prevFilters) => ({
+      ...prevFilters,
+      videoType: e.target.value as HelixVideoType | 'all'
+    }));
+  }
 
+  const [videoType, setVideoType] = useState<HelixVideoType | undefined | 'all'>('archive');
+  const [hideVideos, setHideVideos] = useState(true);
   const [filteredVideos, setFilteredVideos] = React.useState<HelixVideo[] | undefined | null>(null);
-  const { isError, isLoading, data } = useGetTwitchVideos(userId, filters.videoType);
+  const { isError, isLoading, data } = useGetTwitchVideos(userId, videoType);
 
   return (
     <section>
@@ -53,7 +60,13 @@ const TwitchChannelVideos = ({ userId }: TwitchChannelVideosProps) => {
       {/*Ensure an option exists to clear all filters*/}
       <button onClick={() => setFilteredVideos(data ? data : null)}>Clear filters</button>
 
-
+      <div>
+        <label htmlFor="videoType">Video type</label>
+        <select defaultValue={videoType} onChange={handleOptionSelect} name="videoType" id="videoType">
+          <option value="all" data-testid="allOption">All videos</option>
+          <option value="archive" data-testid="broadcastOption">Broadcasts</option>
+        </select>
+      </div>
 
       <div className={styles.container}>
         {hideVideos && <div className={styles.overlay} data-testid="overlay">
@@ -61,7 +74,6 @@ const TwitchChannelVideos = ({ userId }: TwitchChannelVideosProps) => {
         </div>}
         {data && (
           <div className={styles.videosList}>
-
             {data.length > 0 ? (
               <>
                 {data.map((video) => (

--- a/components/TwitchChannelVideos.tsx
+++ b/components/TwitchChannelVideos.tsx
@@ -28,9 +28,8 @@ const TwitchChannelVideos = ({ userId }: TwitchChannelVideosProps) => {
     videoType: 'archive'
   });
 
-  const { isError, isLoading, data } = useGetTwitchVideos(userId, filters.videoType);
   const [filteredVideos, setFilteredVideos] = React.useState<HelixVideo[] | undefined | null>(null);
-
+  const { isError, isLoading, data } = useGetTwitchVideos(userId, filters.videoType);
 
   return (
     <section>
@@ -39,7 +38,12 @@ const TwitchChannelVideos = ({ userId }: TwitchChannelVideosProps) => {
 
       {isError && (<div>An error has occurred</div>)}
 
-      <TwitchFilterMenu filters={filters} setFilters={setFilters}/>
+      <TwitchFilterMenu
+        filters={filters}
+        setFilters={setFilters}
+        filteredVideos={filteredVideos}
+        setFilteredVideos={setFilteredVideos}
+      />
 
       {/*Ensure an option exists to clear all filters*/}
       <button onClick={() => setFilteredVideos(data ? data : null)}>Clear filters</button>

--- a/components/TwitchChannelVideos.tsx
+++ b/components/TwitchChannelVideos.tsx
@@ -9,48 +9,34 @@ interface TwitchChannelVideosProps {
   userId: string;
 }
 
+interface VideoFilters {
+  dateFilter: Date | null;
+  durationFilter: number | null;
+  keywordFilter: string | null;
+  videoType: HelixVideoType | undefined | 'all';
+}
+
 // Make API call here to fetch videos using channel/user ID
 // * Use the archive video type filter to get past broadcasts!!
 
 const TwitchChannelVideos = ({ userId }: TwitchChannelVideosProps) => {
-  const [videoType, setVideoType] = React.useState<HelixVideoType | undefined | 'all'>('archive');
-  const { isError, isLoading, data } = useGetTwitchVideos(userId, videoType);
+  const [filters, setFilters] = React.useState<VideoFilters>({
+    dateFilter: null,
+    durationFilter: null,
+    keywordFilter: null,
+    videoType: 'archive'
+  });
+
+  const { isError, isLoading, data } = useGetTwitchVideos(userId, filters.videoType);
   const [filteredVideos, setFilteredVideos] = React.useState<HelixVideo[] | undefined | null>(null);
-
-  const [dateFilter, setDateFilter] = React.useState<Date | null>(null);
-  const [durationFilter, setDurationFilter] = React.useState<number | null>(null);
-  const [keywordFilter, setKeywordFilter] = React.useState<string | null>(null);
-
 
   const handleOptionSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     // This typecasting is required, as you cannot simply assign the 'string' value type to the videoType state
-    setVideoType(e.target.value as HelixVideoType | 'all');
+    setFilters((prevFilters) => ({
+      ...prevFilters,
+        videoType: e.target.value as HelixVideoType | 'all'
+    }));
   }
-
-  // The use of an effect here ensures that the data set is not only filtered before initial rendering of data, but is open to modification after the data has been rendered.
-  React.useEffect(() => {
-    if (data && filteredVideos) {   // cannot filter data set until it is available
-
-      // Set initial data set to filteredVideos state. This only runs on initial render
-      if (filteredVideos === null) {
-        setFilteredVideos(data)
-      }
-
-      // Re-filter videos
-      if (dateFilter) {
-        setFilteredVideos(filterByDate(filteredVideos, dateFilter));
-      }
-
-      if (durationFilter) {
-        setFilteredVideos(filterByDuration(filteredVideos, durationFilter));
-      }
-
-      if (keywordFilter) {
-        setFilteredVideos(filterByKeyword(filteredVideos, keywordFilter));
-      }
-    }
-  }, [data, dateFilter, durationFilter, keywordFilter]);
-
 
   return (
     <section>
@@ -60,7 +46,7 @@ const TwitchChannelVideos = ({ userId }: TwitchChannelVideosProps) => {
       {isError && (<div>An error has occurred</div>)}
 
       <label htmlFor="videoType">Video type</label>
-      <select defaultValue={videoType} onChange={handleOptionSelect} name="videoType" id="videoType">
+      <select defaultValue={filters.videoType} onChange={handleOptionSelect} name="videoType" id="videoType">
         <option value="all" data-testid="allOption">All videos</option>
         <option value="archive" data-testid="broadcastOption">Broadcasts</option>
       </select>

--- a/components/TwitchChannelVideos.tsx
+++ b/components/TwitchChannelVideos.tsx
@@ -39,6 +39,7 @@ const TwitchChannelVideos = ({ userId }: TwitchChannelVideosProps) => {
   useEffect(() => {
     let tempVideos: HelixVideo[] = [];
     if (data) {
+      console.log(data)
       // Attempting filter without data will throw an error
       tempVideos = data;
       if (filters) {

--- a/components/TwitchChannelVideos.tsx
+++ b/components/TwitchChannelVideos.tsx
@@ -12,7 +12,8 @@ interface TwitchChannelVideosProps {
 
 export interface VideoFilters {
   dateFilter: Date | null;
-  durationFilter: number | null;
+  minDurationFilter: number | null;
+  maxDurationFilter: number | null;
   keywordFilter: string | null;
   videoType: HelixVideoType | undefined | 'all';
 }
@@ -23,7 +24,8 @@ export interface VideoFilters {
 const TwitchChannelVideos = ({ userId }: TwitchChannelVideosProps) => {
   const [filters, setFilters] = React.useState<VideoFilters>({
     dateFilter: null,
-    durationFilter: null,
+    minDurationFilter: null,
+    maxDurationFilter: null,
     keywordFilter: null,
     videoType: 'archive'
   });

--- a/components/TwitchChannelVideos.tsx
+++ b/components/TwitchChannelVideos.tsx
@@ -13,7 +13,7 @@ interface TwitchChannelVideosProps {
 
 const TwitchChannelVideos = ({ userId }: TwitchChannelVideosProps) => {
   const [videoType, setVideoType] = React.useState<HelixVideoType | undefined | 'all'>('archive');
-  const { isError, isLoading, data, error } = useGetTwitchVideos(userId, videoType);
+  const { isError, isLoading, data } = useGetTwitchVideos(userId, videoType);
 
   const handleOptionSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     // This typecasting is required, as you cannot simply assign the 'string' value type to the videoType state

--- a/components/TwitchChannelVideos.tsx
+++ b/components/TwitchChannelVideos.tsx
@@ -4,12 +4,13 @@ import TwitchVideoListing from './TwitchVideoListing';
 import * as React from 'react';
 import styles from '../styles/componentStyles/TwitchChannelVideos.module.css';
 import {filterByDate, filterByDuration, filterByKeyword} from "../helpers/twitchVideoFilters";
+import TwitchFilterMenu from "@/components/TwitchFilterMenu";
 
 interface TwitchChannelVideosProps {
   userId: string;
 }
 
-interface VideoFilters {
+export interface VideoFilters {
   dateFilter: Date | null;
   durationFilter: number | null;
   keywordFilter: string | null;
@@ -30,13 +31,6 @@ const TwitchChannelVideos = ({ userId }: TwitchChannelVideosProps) => {
   const { isError, isLoading, data } = useGetTwitchVideos(userId, filters.videoType);
   const [filteredVideos, setFilteredVideos] = React.useState<HelixVideo[] | undefined | null>(null);
 
-  const handleOptionSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    // This typecasting is required, as you cannot simply assign the 'string' value type to the videoType state
-    setFilters((prevFilters) => ({
-      ...prevFilters,
-        videoType: e.target.value as HelixVideoType | 'all'
-    }));
-  }
 
   return (
     <section>
@@ -45,11 +39,7 @@ const TwitchChannelVideos = ({ userId }: TwitchChannelVideosProps) => {
 
       {isError && (<div>An error has occurred</div>)}
 
-      <label htmlFor="videoType">Video type</label>
-      <select defaultValue={filters.videoType} onChange={handleOptionSelect} name="videoType" id="videoType">
-        <option value="all" data-testid="allOption">All videos</option>
-        <option value="archive" data-testid="broadcastOption">Broadcasts</option>
-      </select>
+      <TwitchFilterMenu filters={filters} setFilters={setFilters}/>
 
       {/*Ensure an option exists to clear all filters*/}
       <button onClick={() => setFilteredVideos(data ? data : null)}>Clear filters</button>

--- a/components/TwitchChannelVideos.tsx
+++ b/components/TwitchChannelVideos.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import styles from '../styles/componentStyles/TwitchChannelVideos.module.css';
 import {filterByDate, filterByDuration, filterByKeyword} from "../helpers/twitchVideoFilters";
 import TwitchFilterMenu from "@/components/TwitchFilterMenu";
+import {useState} from "react";
 
 interface TwitchChannelVideosProps {
   userId: string;
@@ -30,6 +31,8 @@ const TwitchChannelVideos = ({ userId }: TwitchChannelVideosProps) => {
     videoType: 'archive'
   });
 
+  const [hideVideos, setHideVideos] = useState(true);
+
   const [filteredVideos, setFilteredVideos] = React.useState<HelixVideo[] | undefined | null>(null);
   const { isError, isLoading, data } = useGetTwitchVideos(userId, filters.videoType);
 
@@ -50,19 +53,29 @@ const TwitchChannelVideos = ({ userId }: TwitchChannelVideosProps) => {
       {/*Ensure an option exists to clear all filters*/}
       <button onClick={() => setFilteredVideos(data ? data : null)}>Clear filters</button>
 
-      {data && (
-        <div className={styles.videosList}>
-          {data.length > 0 ? (
-            <>
-              {data.map((video) => (
-                <TwitchVideoListing key={video.id} videoData={video} />
-              ))}
-            </>
-          ) : (
-            <div>No videos</div>
-          )}
-        </div>
-      )}
+
+
+      <div className={styles.container}>
+        {hideVideos && <div className={styles.overlay} data-testid="overlay">
+          <button onClick={() => setHideVideos(false)}>Reveal videos</button>
+        </div>}
+        {data && (
+          <div className={styles.videosList}>
+
+            {data.length > 0 ? (
+              <>
+                {data.map((video) => (
+                  <TwitchVideoListing key={video.id} videoData={video} />
+                ))}
+              </>
+            ) : (
+              <div>No videos</div>
+            )}
+          </div>
+        )}
+      </div>
+
+
     </section>
   )
 }

--- a/components/TwitchChannelVideos.tsx
+++ b/components/TwitchChannelVideos.tsx
@@ -2,7 +2,8 @@ import { HelixVideoType } from '@twurple/api/lib';
 import { useGetTwitchVideos } from '../hooks/useGetTwitchVideos'
 import TwitchVideoListing from './TwitchVideoListing';
 import * as React from 'react';
-import styles from '../styles/componentStyles/TwitchChannelVideos.module.css'
+import styles from '../styles/componentStyles/TwitchChannelVideos.module.css';
+import {filterByDate, filterByDuration, filterByKeyword} from "../helpers/twitchVideoFilters";
 
 interface TwitchChannelVideosProps {
   userId: string;

--- a/components/TwitchFilterMenu.tsx
+++ b/components/TwitchFilterMenu.tsx
@@ -1,13 +1,16 @@
 import {VideoFilters} from "../components/TwitchChannelVideos";
 import * as React from "react";
 import {HelixVideoType} from "@twurple/api";
+import {HelixVideo} from "@twurple/api/lib";
 
 interface TwitchFilterMenuProps {
-  filters: VideoFilters
-  setFilters: React.Dispatch<React.SetStateAction<VideoFilters>>
+  filters: VideoFilters;
+  setFilters: React.Dispatch<React.SetStateAction<VideoFilters>>;
+  filteredVideos: HelixVideo[] | undefined | null;
+  setFilteredVideos: React.Dispatch<React.SetStateAction<HelixVideo[] | null | undefined>>;
 }
 
-const TwitchFilterMenu = ({filters, setFilters}: TwitchFilterMenuProps) => {
+const TwitchFilterMenu = ({filters, setFilters, filteredVideos, setFilteredVideos}: TwitchFilterMenuProps) => {
 
   const handleOptionSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     // This typecasting is required, as you cannot simply assign the 'string' value type to the videoType state

--- a/components/TwitchFilterMenu.tsx
+++ b/components/TwitchFilterMenu.tsx
@@ -11,23 +11,17 @@ interface TwitchFilterMenuProps {
   setFilteredVideos: React.Dispatch<React.SetStateAction<HelixVideo[] | null | undefined>>;
 }
 
-const TwitchFilterMenu = ({filters, setFilters, filteredVideos, setFilteredVideos}: TwitchFilterMenuProps) => {
+const TwitchFilterMenu = ({filters, setFilters}: TwitchFilterMenuProps) => {
 
-  const handleOptionSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    // This typecasting is required, as you cannot simply assign the 'string' value type to the videoType state
-    setFilters((prevFilters) => ({
-      ...prevFilters,
-      videoType: e.target.value as HelixVideoType | 'all'
-    }));
-  }
+
 
   const [showFilters, setShowFilters] = useState(false);
 
-  // Unique states are used for each filter within this component
-  const [keyword, setKeyword] = useState(filters.keywordFilter ? filters.keywordFilter : '');
-  const [minDuration, setMinDuration] = useState(filters.minDurationFilter ? filters.minDurationFilter : 0);
-  const [maxDuration, setMaxDuration] = useState(filters.maxDurationFilter ? filters.maxDurationFilter : 180000);
-  const [date, setDate] = useState(filters.dateFilter ? filters.dateFilter : new Date());
+  // Unique states are used for each filter within this component to avoid causing a re-render of the parent component on any filter change
+  const [keyword, setKeyword] = useState('');
+  const [minDuration, setMinDuration] = useState(0);
+  const [maxDuration, setMaxDuration] = useState(180000);
+  const [date, setDate] = useState(new Date());
 
   // Convenience function used when a radio button is clicked. It allows easy min/max setting in one function call
   const setDuration = (minDuration: number, maxDuration: number) => {
@@ -35,7 +29,15 @@ const TwitchFilterMenu = ({filters, setFilters, filteredVideos, setFilteredVideo
     setMaxDuration(maxDuration)
   }
 
-  console.log(minDuration, maxDuration)
+  const applyFilters = () => {
+    setFilters({
+      keywordFilter: keyword,
+      minDurationFilter: minDuration,
+      maxDurationFilter: maxDuration,
+      dateFilter: date,
+      videoType
+    })
+  }
 
   return (
     <div>
@@ -84,13 +86,8 @@ const TwitchFilterMenu = ({filters, setFilters, filteredVideos, setFilteredVideo
             <label htmlFor="keyword">Keyword</label>
             <input type="text" id="keyword" value={keyword} onChange={(e) =>  setKeyword(e.target.value)} />
           </div>
-          <div>
-            <label htmlFor="videoType">Video type</label>
-            <select defaultValue={filters.videoType} onChange={handleOptionSelect} name="videoType" id="videoType">
-              <option value="all" data-testid="allOption">All videos</option>
-              <option value="archive" data-testid="broadcastOption">Broadcasts</option>
-            </select>
-          </div>
+
+          <button>Apply filters</button>
         </div>
       )}
     </div>

--- a/components/TwitchFilterMenu.tsx
+++ b/components/TwitchFilterMenu.tsx
@@ -1,7 +1,5 @@
 import {VideoFilters} from "../components/TwitchChannelVideos";
 import * as React from "react";
-import {HelixVideoType} from "@twurple/api";
-import {HelixVideo} from "@twurple/api/lib";
 import {useState} from "react";
 
 interface TwitchFilterMenuProps {
@@ -10,9 +8,6 @@ interface TwitchFilterMenuProps {
 }
 
 const TwitchFilterMenu = ({filters, setFilters}: TwitchFilterMenuProps) => {
-
-
-
   const [showFilters, setShowFilters] = useState(false);
 
   // Unique states are used for each filter within this component to avoid causing a re-render of the parent component on any filter change
@@ -84,7 +79,7 @@ const TwitchFilterMenu = ({filters, setFilters}: TwitchFilterMenuProps) => {
             <input type="text" id="keyword" value={keyword} onChange={(e) =>  setKeyword(e.target.value)} />
           </div>
 
-          <button>Apply filters</button>
+          <button onClick={applyFilters}>Apply filters</button>
         </div>
       )}
     </div>

--- a/components/TwitchFilterMenu.tsx
+++ b/components/TwitchFilterMenu.tsx
@@ -21,6 +21,8 @@ const TwitchFilterMenu = ({filters, setFilters, filteredVideos, setFilteredVideo
     }));
   }
 
+  const [showFilters, setShowFilters] = useState(false);
+
   // Unique states are used for each filter within this component
   const [keyword, setKeyword] = useState(filters.keywordFilter ? filters.keywordFilter : '');
   const [minDuration, setMinDuration] = useState(filters.minDurationFilter ? filters.minDurationFilter : 0);
@@ -38,55 +40,59 @@ const TwitchFilterMenu = ({filters, setFilters, filteredVideos, setFilteredVideo
   return (
     <div>
       {/*Expand and collapse the filter menu*/}
-      <button>Filters</button>
+      <button onClick={() => setShowFilters((prevState) => !prevState)}>Filters</button>
 
-      <div>
-        <h4>Upload date</h4>
-        <label htmlFor="date">Uploaded before date</label>
-        <input type="date" id="date" value={date.toLocaleDateString('en-CA')} onChange={(e) =>  setDate(new Date(e.target.valueAsNumber))}/>
-      </div>
-      <div>
-        <h4>Duration</h4>
-        <fieldset>
-          <legend>Select a duration</legend>
+      {showFilters && (
+        <div>
           <div>
-            <input type="radio" id="anyDuration" name="duration" onChange={() => setDuration(0, 180000)} checked={minDuration === 0 && maxDuration === 180000}/>
-            <label htmlFor="anyDuration">Any duration</label>
+            <h4>Upload date</h4>
+            <label htmlFor="date">Uploaded before date</label>
+            <input type="date" id="date" value={date.toLocaleDateString('en-CA')} onChange={(e) =>  setDate(new Date(e.target.valueAsNumber))}/>
           </div>
+          <div>
+            <h4>Duration</h4>
+            <fieldset>
+              <legend>Select a duration</legend>
+              <div>
+                <input type="radio" id="anyDuration" name="duration" onChange={() => setDuration(0, 180000)} checked={minDuration === 0 && maxDuration === 180000}/>
+                <label htmlFor="anyDuration">Any duration</label>
+              </div>
 
-          <div>
-            <input type="radio" id="durationOne" name="duration" onChange={() => setDuration(0, 300)}/>
-            <label htmlFor="durationOne">Under 5 minutes</label>
-          </div>
+              <div>
+                <input type="radio" id="durationOne" name="duration" onChange={() => setDuration(0, 300)}/>
+                <label htmlFor="durationOne">Under 5 minutes</label>
+              </div>
 
-          <div>
-            <input type="radio" id="durationTwo" name="duration" onChange={() => setDuration(300, 3600)} />
-            <label htmlFor="durationTwo">5 - 60 minutes</label>
-          </div>
+              <div>
+                <input type="radio" id="durationTwo" name="duration" onChange={() => setDuration(300, 3600)} />
+                <label htmlFor="durationTwo">5 - 60 minutes</label>
+              </div>
 
-          <div>
-            <input type="radio" id="durationThree" name="duration" onChange={() => setDuration(3600, 14400)} />
-            <label htmlFor="durationThree">1 - 4 hours</label>
-          </div>
+              <div>
+                <input type="radio" id="durationThree" name="duration" onChange={() => setDuration(3600, 14400)} />
+                <label htmlFor="durationThree">1 - 4 hours</label>
+              </div>
 
-          <div>
-            <input type="radio" id="durationFour" name="duration" onChange={() => setDuration(14400, 180000)} />
-            <label htmlFor="durationFour">Over 4 hours</label>
+              <div>
+                <input type="radio" id="durationFour" name="duration" onChange={() => setDuration(14400, 180000)} />
+                <label htmlFor="durationFour">Over 4 hours</label>
+              </div>
+            </fieldset>
           </div>
-        </fieldset>
-      </div>
-      <div>
-        <h4>Keyword Search</h4>
-        <label htmlFor="keyword">Keyword</label>
-        <input type="text" id="keyword" value={keyword} onChange={(e) =>  setKeyword(e.target.value)} />
-      </div>
-      <div>
-        <label htmlFor="videoType">Video type</label>
-        <select defaultValue={filters.videoType} onChange={handleOptionSelect} name="videoType" id="videoType">
-          <option value="all" data-testid="allOption">All videos</option>
-          <option value="archive" data-testid="broadcastOption">Broadcasts</option>
-        </select>
-      </div>
+          <div>
+            <h4>Keyword Search</h4>
+            <label htmlFor="keyword">Keyword</label>
+            <input type="text" id="keyword" value={keyword} onChange={(e) =>  setKeyword(e.target.value)} />
+          </div>
+          <div>
+            <label htmlFor="videoType">Video type</label>
+            <select defaultValue={filters.videoType} onChange={handleOptionSelect} name="videoType" id="videoType">
+              <option value="all" data-testid="allOption">All videos</option>
+              <option value="archive" data-testid="broadcastOption">Broadcasts</option>
+            </select>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/components/TwitchFilterMenu.tsx
+++ b/components/TwitchFilterMenu.tsx
@@ -1,0 +1,26 @@
+
+const TwitchFilterMenu = () => {
+
+
+  return (
+    <div>
+      {/*Expand and collapse the filter menu*/}
+      <button>Filters</button>
+
+      <div>
+        <h4>Upload date</h4>
+      </div>
+      <div>
+        <h4>Duration</h4>
+      </div>
+      <div>
+        <h4>Keyword Search</h4>
+      </div>
+      <div>
+        <h4>Type</h4>
+      </div>
+    </div>
+  );
+};
+
+export default TwitchFilterMenu;

--- a/components/TwitchFilterMenu.tsx
+++ b/components/TwitchFilterMenu.tsx
@@ -27,6 +27,14 @@ const TwitchFilterMenu = ({filters, setFilters, filteredVideos, setFilteredVideo
   const [maxDuration, setMaxDuration] = useState(filters.maxDurationFilter ? filters.maxDurationFilter : 180000);
   const [date, setDate] = useState(filters.dateFilter ? filters.dateFilter : new Date());
 
+  // Convenience function used when a radio button is clicked. It allows easy min/max setting in one function call
+  const setDuration = (minDuration: number, maxDuration: number) => {
+    setMinDuration(minDuration);
+    setMaxDuration(maxDuration)
+  }
+
+  console.log(minDuration, maxDuration)
+
   return (
     <div>
       {/*Expand and collapse the filter menu*/}
@@ -39,11 +47,34 @@ const TwitchFilterMenu = ({filters, setFilters, filteredVideos, setFilteredVideo
       </div>
       <div>
         <h4>Duration</h4>
-        <label htmlFor="minDuration">Min duration</label>
-        <input type="number" id="minDuration" value={minDuration} onChange={(e) =>  setMinDuration(parseInt(e.target.value))}/>
+        <fieldset>
+          <legend>Select a duration</legend>
 
-        <label htmlFor="maxDuration">Max duration</label>
-        <input type="number" id="maxDuration" value={maxDuration} onChange={(e) =>  setMaxDuration(parseInt(e.target.value))}/>
+          <div>
+            <input type="radio" id="anyDuration" name="duration" onChange={() => setDuration(0, 180000)} checked={minDuration === 0 && maxDuration === 180000}/>
+            <label htmlFor="anyDuration">Any duration</label>
+          </div>
+
+          <div>
+            <input type="radio" id="durationOne" name="duration" onChange={() => setDuration(0, 300)}/>
+            <label htmlFor="durationOne">Under 5 minutes</label>
+          </div>
+
+          <div>
+            <input type="radio" id="durationTwo" name="duration" onChange={() => setDuration(300, 3600)} />
+            <label htmlFor="durationTwo">5 - 60 minutes</label>
+          </div>
+
+          <div>
+            <input type="radio" id="durationThree" name="duration" onChange={() => setDuration(3600, 14400)} />
+            <label htmlFor="durationThree">1 - 4 hours</label>
+          </div>
+
+          <div>
+            <input type="radio" id="durationFour" name="duration" onChange={() => setDuration(14400, 180000)} />
+            <label htmlFor="durationFour">Over 4 hours</label>
+          </div>
+        </fieldset>
       </div>
       <div>
         <h4>Keyword Search</h4>

--- a/components/TwitchFilterMenu.tsx
+++ b/components/TwitchFilterMenu.tsx
@@ -49,7 +49,6 @@ const TwitchFilterMenu = ({filters, setFilters, filteredVideos, setFilteredVideo
         <h4>Duration</h4>
         <fieldset>
           <legend>Select a duration</legend>
-
           <div>
             <input type="radio" id="anyDuration" name="duration" onChange={() => setDuration(0, 180000)} checked={minDuration === 0 && maxDuration === 180000}/>
             <label htmlFor="anyDuration">Any duration</label>
@@ -79,7 +78,7 @@ const TwitchFilterMenu = ({filters, setFilters, filteredVideos, setFilteredVideo
       <div>
         <h4>Keyword Search</h4>
         <label htmlFor="keyword">Keyword</label>
-        <input type="text" id="keyword" value={keyword} onChange={(e) =>  setKeyword(e.target.value)}/>
+        <input type="text" id="keyword" value={keyword} onChange={(e) =>  setKeyword(e.target.value)} />
       </div>
       <div>
         <label htmlFor="videoType">Video type</label>

--- a/components/TwitchFilterMenu.tsx
+++ b/components/TwitchFilterMenu.tsx
@@ -7,8 +7,6 @@ import {useState} from "react";
 interface TwitchFilterMenuProps {
   filters: VideoFilters;
   setFilters: React.Dispatch<React.SetStateAction<VideoFilters>>;
-  filteredVideos: HelixVideo[] | undefined | null;
-  setFilteredVideos: React.Dispatch<React.SetStateAction<HelixVideo[] | null | undefined>>;
 }
 
 const TwitchFilterMenu = ({filters, setFilters}: TwitchFilterMenuProps) => {
@@ -35,7 +33,6 @@ const TwitchFilterMenu = ({filters, setFilters}: TwitchFilterMenuProps) => {
       minDurationFilter: minDuration,
       maxDurationFilter: maxDuration,
       dateFilter: date,
-      videoType
     })
   }
 

--- a/components/TwitchFilterMenu.tsx
+++ b/components/TwitchFilterMenu.tsx
@@ -2,6 +2,7 @@ import {VideoFilters} from "../components/TwitchChannelVideos";
 import * as React from "react";
 import {HelixVideoType} from "@twurple/api";
 import {HelixVideo} from "@twurple/api/lib";
+import {useState} from "react";
 
 interface TwitchFilterMenuProps {
   filters: VideoFilters;
@@ -20,6 +21,12 @@ const TwitchFilterMenu = ({filters, setFilters, filteredVideos, setFilteredVideo
     }));
   }
 
+  // Unique states are used for each filter within this component
+  const [keyword, setKeyword] = useState(filters.keywordFilter ? filters.keywordFilter : '');
+  const [minDuration, setMinDuration] = useState(filters.minDurationFilter ? filters.minDurationFilter : 0);
+  const [maxDuration, setMaxDuration] = useState(filters.maxDurationFilter ? filters.maxDurationFilter : 180000);
+  const [date, setDate] = useState(filters.dateFilter ? filters.dateFilter : new Date());
+
   return (
     <div>
       {/*Expand and collapse the filter menu*/}
@@ -27,12 +34,21 @@ const TwitchFilterMenu = ({filters, setFilters, filteredVideos, setFilteredVideo
 
       <div>
         <h4>Upload date</h4>
+        <label htmlFor="date">Uploaded before date</label>
+        <input type="date" id="date" value={date.toLocaleDateString('en-CA')} onChange={(e) =>  setDate(new Date(e.target.valueAsNumber))}/>
       </div>
       <div>
         <h4>Duration</h4>
+        <label htmlFor="minDuration">Min duration</label>
+        <input type="number" id="minDuration" value={minDuration} onChange={(e) =>  setMinDuration(parseInt(e.target.value))}/>
+
+        <label htmlFor="maxDuration">Max duration</label>
+        <input type="number" id="maxDuration" value={maxDuration} onChange={(e) =>  setMaxDuration(parseInt(e.target.value))}/>
       </div>
       <div>
         <h4>Keyword Search</h4>
+        <label htmlFor="keyword">Keyword</label>
+        <input type="text" id="keyword" value={keyword} onChange={(e) =>  setKeyword(e.target.value)}/>
       </div>
       <div>
         <label htmlFor="videoType">Video type</label>

--- a/components/TwitchFilterMenu.tsx
+++ b/components/TwitchFilterMenu.tsx
@@ -3,11 +3,10 @@ import * as React from "react";
 import {useState} from "react";
 
 interface TwitchFilterMenuProps {
-  filters: VideoFilters;
-  setFilters: React.Dispatch<React.SetStateAction<VideoFilters>>;
+  setFilters: React.Dispatch<React.SetStateAction<VideoFilters | null>>;
 }
 
-const TwitchFilterMenu = ({filters, setFilters}: TwitchFilterMenuProps) => {
+const TwitchFilterMenu = ({setFilters}: TwitchFilterMenuProps) => {
   const [showFilters, setShowFilters] = useState(false);
 
   // Unique states are used for each filter within this component to avoid causing a re-render of the parent component on any filter change

--- a/components/TwitchFilterMenu.tsx
+++ b/components/TwitchFilterMenu.tsx
@@ -1,6 +1,21 @@
+import {VideoFilters} from "../components/TwitchChannelVideos";
+import * as React from "react";
+import {HelixVideoType} from "@twurple/api";
 
-const TwitchFilterMenu = () => {
+interface TwitchFilterMenuProps {
+  filters: VideoFilters
+  setFilters: React.Dispatch<React.SetStateAction<VideoFilters>>
+}
 
+const TwitchFilterMenu = ({filters, setFilters}: TwitchFilterMenuProps) => {
+
+  const handleOptionSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    // This typecasting is required, as you cannot simply assign the 'string' value type to the videoType state
+    setFilters((prevFilters) => ({
+      ...prevFilters,
+      videoType: e.target.value as HelixVideoType | 'all'
+    }));
+  }
 
   return (
     <div>
@@ -17,7 +32,11 @@ const TwitchFilterMenu = () => {
         <h4>Keyword Search</h4>
       </div>
       <div>
-        <h4>Type</h4>
+        <label htmlFor="videoType">Video type</label>
+        <select defaultValue={filters.videoType} onChange={handleOptionSelect} name="videoType" id="videoType">
+          <option value="all" data-testid="allOption">All videos</option>
+          <option value="archive" data-testid="broadcastOption">Broadcasts</option>
+        </select>
       </div>
     </div>
   );

--- a/helpers/twitchVideoFilters.ts
+++ b/helpers/twitchVideoFilters.ts
@@ -1,11 +1,16 @@
 // These functions are intended for use in the TwitchChannelVideos component to filter the returned videos data set according to the specifications
 
+import {HelixVideo} from "@twurple/api/lib";
+
 export const filterByDate = () => {
 
 };
 
-export const filterByDuration = () => {
-
+// Currently this only takes a minimum duration, and is used to return only those videos longer than the specified duration
+export const filterByDuration = (videos: HelixVideo[], minimumDurationInSeconds: number,) => {
+  const filteredVideos = videos.filter((video) => {
+    return video.durationInSeconds > minimumDurationInSeconds;
+  })
 };
 
 // Essentially used as a search function with a user provided keyword/search query

--- a/helpers/twitchVideoFilters.ts
+++ b/helpers/twitchVideoFilters.ts
@@ -19,10 +19,10 @@ export const filterByDuration = (videos: HelixVideo[], minimumDurationInSeconds 
   return filteredVideos;
 };
 
-// Essentially used as a search function with a user provided keyword/search query
+// Essentially used as a search function with a user provided keyword/search query. All strings must be case-matched before comparison occurs to avoid a case-sensitive search
 export const filterByKeyword = (videos: HelixVideo[], keyword: string) => {
   const filteredVideos = videos.filter((video) => {
-    return video.title.includes(keyword.trim());
+    return video.title.toLowerCase().includes(keyword.trim().toLowerCase());
   });
 
   return filteredVideos;

--- a/helpers/twitchVideoFilters.ts
+++ b/helpers/twitchVideoFilters.ts
@@ -7,7 +7,7 @@ export const filterByDate = () => {
 };
 
 // Currently this only takes a minimum duration, and is used to return only those videos longer than the specified duration
-export const filterByDuration = (videos: HelixVideo[], minimumDurationInSeconds: number,) => {
+export const filterByDuration = (videos: HelixVideo[], minimumDurationInSeconds: number) => {
   const filteredVideos = videos.filter((video) => {
     return video.durationInSeconds > minimumDurationInSeconds;
   });
@@ -16,7 +16,11 @@ export const filterByDuration = (videos: HelixVideo[], minimumDurationInSeconds:
 };
 
 // Essentially used as a search function with a user provided keyword/search query
-export const filterByKeyword = () => {
+export const filterByKeyword = (videos: HelixVideo[], keyword: string) => {
+  const filteredVideos = videos.filter((video) => {
+    return video.title.includes(keyword.trim());
+  });
 
+  return filteredVideos;
 };
 

--- a/helpers/twitchVideoFilters.ts
+++ b/helpers/twitchVideoFilters.ts
@@ -1,0 +1,15 @@
+// These functions are intended for use in the TwitchChannelVideos component to filter the returned videos data set according to the specifications
+
+export const filterByDate = () => {
+
+};
+
+export const filterByDuration = () => {
+
+};
+
+// Essentially used as a search function with a user provided keyword/search query
+export const filterByKeyword = () => {
+
+};
+

--- a/helpers/twitchVideoFilters.ts
+++ b/helpers/twitchVideoFilters.ts
@@ -10,7 +10,9 @@ export const filterByDate = () => {
 export const filterByDuration = (videos: HelixVideo[], minimumDurationInSeconds: number,) => {
   const filteredVideos = videos.filter((video) => {
     return video.durationInSeconds > minimumDurationInSeconds;
-  })
+  });
+
+  return filteredVideos;
 };
 
 // Essentially used as a search function with a user provided keyword/search query

--- a/helpers/twitchVideoFilters.ts
+++ b/helpers/twitchVideoFilters.ts
@@ -10,10 +10,10 @@ export const filterByDate = (videos: HelixVideo[], dateLimit: Date) => {
   return filteredVideos;
 };
 
-// Currently this only takes a minimum duration, and is used to return only those videos longer than the specified duration
-export const filterByDuration = (videos: HelixVideo[], minimumDurationInSeconds: number) => {
+// The 0 minimum is self-explanatory; the 180000 maximum is equivalent to 50 hours. This more than covers the max Twitch stream length of 48
+export const filterByDuration = (videos: HelixVideo[], minimumDurationInSeconds = 0, maximumDurationInSeconds = 180000) => {
   const filteredVideos = videos.filter((video) => {
-    return video.durationInSeconds > minimumDurationInSeconds;
+    return (video.durationInSeconds > minimumDurationInSeconds) && (video.durationInSeconds < maximumDurationInSeconds);
   });
 
   return filteredVideos;

--- a/helpers/twitchVideoFilters.ts
+++ b/helpers/twitchVideoFilters.ts
@@ -2,8 +2,12 @@
 
 import {HelixVideo} from "@twurple/api/lib";
 
-export const filterByDate = () => {
+export const filterByDate = (videos: HelixVideo[], oldestCreationDate: Date) => {
+  const filteredVideos = videos.filter((video) => {
+    return video.creationDate >= oldestCreationDate;
+  });
 
+  return filteredVideos;
 };
 
 // Currently this only takes a minimum duration, and is used to return only those videos longer than the specified duration

--- a/helpers/twitchVideoFilters.ts
+++ b/helpers/twitchVideoFilters.ts
@@ -1,10 +1,10 @@
 // These functions are intended for use in the TwitchChannelVideos component to filter the returned videos data set according to the specifications
-
 import {HelixVideo} from "@twurple/api/lib";
 
-export const filterByDate = (videos: HelixVideo[], oldestCreationDate: Date) => {
+// Able to take any kind of date input. It was decided to include a >= operator as it makes intuitive sense to filter by 'created after this date' to include time later that day ON the date/time selected
+export const filterByDate = (videos: HelixVideo[], dateLimit: Date) => {
   const filteredVideos = videos.filter((video) => {
-    return video.creationDate >= oldestCreationDate;
+    return video.creationDate <= dateLimit;
   });
 
   return filteredVideos;

--- a/helpers/videoDurationConversion.ts
+++ b/helpers/videoDurationConversion.ts
@@ -15,7 +15,7 @@ export const convertTwitchVideoDuration = (duration: string) => {
 
       // Handle the seconds component
       const secondsSplit = minutesSplit[1].split('s');
-      convertedDuration += secondsSplit[0];
+      convertedDuration += secondsSplit[0].length > 1 ? `${secondsSplit[0]}` : `0${secondsSplit[0]}`
     } else {    // duration is seconds only
       // Handle seconds component
       convertedDuration += `0:${duration.split('s')[0]}`;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/react": "18.0.9",
     "@typescript-eslint/eslint-plugin": "^5.26.0",
     "@typescript-eslint/parser": "^5.26.0",
-    "eslint": "^8.16.0",
+    "eslint": "^8.19.0",
     "eslint-config-next": "^12.1.6",
     "eslint-plugin-react": "^7.30.0",
     "eslint-plugin-testing-library": "^5.5.1",

--- a/pages/twitchChannel/[channelId].tsx
+++ b/pages/twitchChannel/[channelId].tsx
@@ -20,7 +20,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
 const TwitchChannel = ({ channelId }: TwitchChannelProps) => {
   const { isLoading, isError, data, error } = useGetTwitchChannel(channelId);
-  const [showVideos, setShowVideos] = useState(false);
+
 
   return (
     <div>
@@ -41,9 +41,8 @@ const TwitchChannel = ({ channelId }: TwitchChannelProps) => {
         </section>
       )}
 
-      <button onClick={() => { setShowVideos((prevState) => !prevState) }}>Toggle videos</button>
-
-      {showVideos && (<TwitchChannelVideos userId={channelId} />)}
+      {/*These will immediately be loaded, but will be obscured by an overlay within the component*/}
+      <TwitchChannelVideos userId={channelId} />
     </div>
   )
 }

--- a/styles/componentStyles/TwitchChannelVideos.module.css
+++ b/styles/componentStyles/TwitchChannelVideos.module.css
@@ -1,3 +1,18 @@
+.container {
+  position: relative;
+}
+
+.overlay {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  top: 0;
+  left: 0;
+  background-color: rgba(255, 255, 255, 0.5);
+  z-index: 1;
+  backdrop-filter: blur(4px);
+}
+
 .videosList {
   display: flex;
   flex-wrap: wrap;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2034,10 +2034,10 @@ eslint-visitor-keys@^3.3.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
-eslint@^8.16.0:
-  version "8.16.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.16.0.tgz#6d936e2d524599f2a86c708483b4c372c5d3bbae"
-  integrity sha512-MBndsoXY/PeVTDJeWsYj7kLZ5hQpJOfMYLsF6LicLHQWbRDG19lK5jOix4DPl8yY4SUFcE3txy86OzFLWT+yoA==
+eslint@^8.19.0:
+  version "8.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.19.0.tgz#7342a3cbc4fbc5c106a1eefe0fd0b50b6b1a7d28"
+  integrity sha512-SXOPj3x9VKvPe81TjjUJCYlV4oJjQw68Uek+AM0X4p+33dj2HY5bpTZOgnQHcG2eAm1mtCU9uNMnJi7exU/kYw==
   dependencies:
     "@eslint/eslintrc" "^1.3.0"
     "@humanwhocodes/config-array" "^0.9.2"


### PR DESCRIPTION
This PR adds additional filtering functions to the Twitch Video Channels page. These filters include the following:
1. Filter by date
2. Filter by duration
3. Filter by keyword (search)

These filters have been included in a filter menu component that is shown optionally on click. The channel videos remain blurred until the user chooses to reveal them, so the filters may be applied while videos are still in a blurred state. The UI has not yet been styled.